### PR TITLE
feat: add update_wrap function (#59)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,85 @@ impl StellarWrapContract {
             .publish((symbol_short!("mint"), user, period), archetype);
     }
 
+    /// Update an existing wrap record's data_hash and archetype (admin-only).
+    ///
+    /// The original `timestamp` is preserved. A new `update` event is emitted.
+    ///
+    /// # Parameters
+    /// - `user`: The address whose wrap record is being updated.
+    /// - `period`: The period identifier of the record to update.
+    /// - `new_data_hash`: Replacement SHA-256 hash. Must not be all-zero bytes.
+    /// - `new_archetype`: Replacement archetype symbol.
+    /// - `signature`: 64-byte Ed25519 signature from the admin over the new payload.
+    ///
+    /// # Authorization
+    /// Requires authorization from the **admin**.
+    ///
+    /// # Panics
+    /// - [`ContractError::NotInitialized`] if the contract has not been initialized.
+    /// - [`ContractError::Unauthorized`] if the caller is not the admin.
+    /// - [`ContractError::InvalidDataHash`] if `new_data_hash` is all-zero bytes.
+    /// - [`ContractError::InvalidSignature`] if the Ed25519 signature is invalid.
+    /// - [`ContractError::WrapNotFound`] if no wrap exists for `(user, period)`.
+    pub fn update_wrap(
+        e: Env,
+        user: Address,
+        period: u64,
+        new_data_hash: BytesN<32>,
+        new_archetype: Symbol,
+        signature: BytesN<64>,
+    ) {
+        let admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+        admin.require_auth();
+
+        let admin_pubkey: BytesN<32> = e
+            .storage()
+            .instance()
+            .get(&DataKey::AdminPubKey)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+        if new_data_hash == BytesN::from_array(&e, &[0u8; 32]) {
+            panic_with_error!(e, ContractError::InvalidDataHash);
+        }
+
+        // Payload: contract_id ‖ user ‖ period ‖ new_archetype ‖ new_data_hash
+        let mut payload = Bytes::new(&e);
+        payload.append(&e.current_contract_address().to_xdr(&e));
+        payload.append(&user.clone().to_xdr(&e));
+        payload.append(&period.to_xdr(&e));
+        payload.append(&new_archetype.clone().to_xdr(&e));
+        payload.append(&new_data_hash.clone().to_xdr(&e));
+        e.crypto()
+            .ed25519_verify(&admin_pubkey, &payload, &signature);
+
+        let wrap_key = DataKey::Wrap(user.clone(), period);
+        let existing: WrapRecord = e
+            .storage()
+            .persistent()
+            .get(&wrap_key)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::WrapNotFound));
+
+        let updated = WrapRecord {
+            timestamp: existing.timestamp, // preserve original timestamp
+            data_hash: new_data_hash,
+            archetype: new_archetype.clone(),
+            period,
+        };
+
+        let ttl_one_year = 17280 * 365;
+        e.storage().persistent().set(&wrap_key, &updated);
+        e.storage()
+            .persistent()
+            .extend_ttl(&wrap_key, ttl_one_year, ttl_one_year);
+
+        e.events()
+            .publish((symbol_short!("update"), user, period), new_archetype);
+    }
+
     /// Admin-only revocation for incorrect or fraudulent records.
     pub fn revoke_wrap(e: Env, user: Address, period: u64) {
         let admin: Address = e

--- a/src/test.rs
+++ b/src/test.rs
@@ -1096,3 +1096,173 @@ fn test_upgrade_requires_admin_auth() {
     let fake_wasm = BytesN::from_array(&env, &[0u8; 32]);
     client.upgrade(&fake_wasm);
 }
+
+// ─── Issue #59: update_wrap tests ──────────────────────────────────────────
+
+fn sign_update_payload(
+    env: &Env,
+    signer: &SigningKey,
+    contract: &Address,
+    user: &Address,
+    period: u64,
+    new_archetype: &Symbol,
+    new_data_hash: &BytesN<32>,
+) -> BytesN<64> {
+    sign_payload(env, signer, contract, user, period, new_archetype, new_data_hash)
+}
+
+#[test]
+fn test_update_wrap_succeeds_and_preserves_timestamp() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[30u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash1 = BytesN::from_array(&env, &[41u8; 32]);
+
+    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
+    client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
+
+    let before = client.get_wrap(&user, &period).unwrap();
+
+    let new_hash = BytesN::from_array(&env, &[99u8; 32]);
+    let new_arch = symbol_short!("builder");
+    let sig2 = sign_update_payload(&env, &signing_key, &contract_id, &user, period, &new_arch, &new_hash);
+    client.update_wrap(&user, &period, &new_hash, &new_arch, &sig2);
+
+    let after = client.get_wrap(&user, &period).unwrap();
+    assert_eq!(after.timestamp, before.timestamp, "Original timestamp must be preserved");
+    assert_eq!(after.data_hash, new_hash);
+    assert_eq!(after.archetype, new_arch);
+    assert_eq!(after.period, period);
+}
+
+#[test]
+fn test_update_wrap_emits_update_event() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[31u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash1 = BytesN::from_array(&env, &[41u8; 32]);
+    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
+    client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
+
+    let new_hash = BytesN::from_array(&env, &[98u8; 32]);
+    let new_arch = symbol_short!("defi");
+    let sig2 = sign_update_payload(&env, &signing_key, &contract_id, &user, period, &new_arch, &new_hash);
+    client.update_wrap(&user, &period, &new_hash, &new_arch, &sig2);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    let (_, topics, data) = last_event;
+
+    let topic_0: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let topic_1: Address = topics.get(1).unwrap().try_into_val(&env).unwrap();
+    let topic_2: u64 = topics.get(2).unwrap().try_into_val(&env).unwrap();
+    let ev_arch: Symbol = data.try_into_val(&env).unwrap();
+
+    assert_eq!(topic_0, symbol_short!("update"));
+    assert_eq!(topic_1, user);
+    assert_eq!(topic_2, period);
+    assert_eq!(ev_arch, new_arch);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_update_wrap_nonexistent_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[32u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let new_hash = BytesN::from_array(&env, &[99u8; 32]);
+    let new_arch = symbol_short!("arch");
+    let sig = sign_update_payload(&env, &signing_key, &contract_id, &user, 9999, &new_arch, &new_hash);
+    client.update_wrap(&user, &9999, &new_hash, &new_arch, &sig);
+}
+
+#[test]
+#[should_panic]
+fn test_update_wrap_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[33u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash1 = BytesN::from_array(&env, &[41u8; 32]);
+    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
+    client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
+
+    // Reset auth — no admin auth mocked
+    let env2 = Env::default();
+    let contract_id2 = env2.register_contract(None, StellarWrapContract);
+    let client2 = StellarWrapContractClient::new(&env2, &contract_id2);
+    client2.initialize(&admin, &admin_pubkey);
+
+    let new_hash = BytesN::from_array(&env2, &[99u8; 32]);
+    let new_arch = symbol_short!("arch");
+    let sig2 = sign_update_payload(&env2, &signing_key, &contract_id2, &user, period, &new_arch, &new_hash);
+    // No auth mocked — must panic
+    client2.update_wrap(&user, &period, &new_hash, &new_arch, &sig2);
+}
+
+#[test]
+#[should_panic]
+fn test_update_wrap_zero_hash_rejected() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[34u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash1 = BytesN::from_array(&env, &[41u8; 32]);
+    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
+    client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
+
+    let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
+    let sig2 = sign_update_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &zero_hash);
+    client.update_wrap(&user, &period, &zero_hash, &archetype, &sig2);
+}


### PR DESCRIPTION
- Admin-only, requires admin auth + Ed25519 signature verification
- Preserves original timestamp on update
- Emits 'update' event (topic: update, user, period; data: new_archetype)
- Rejects zero data_hash and non-existent wrap records
- Tests: success, event emission, not-found, no-auth, zero-hash
closes #59 