### PR TITLE
feat: add contract_info() function (#56)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{
 };
 
 mod storage_types;
-use storage_types::{DataKey, WrapRecord};
+use storage_types::{ContractInfo, DataKey, WrapRecord};
 
 soroban_sdk::contractmeta!(
     key = "Description",
@@ -354,6 +354,16 @@ impl StellarWrapContract {
     /// Return the number of decimals. Soulbound tokens are non-divisible, so this is always `0`.
     pub fn decimals(_e: Env) -> u32 {
         0
+    }
+
+    /// Return contract-level metadata useful for explorers and indexers.
+    pub fn contract_info(e: Env) -> ContractInfo {
+        ContractInfo {
+            name: String::from_str(&e, "Stellar Wrap Registry"),
+            version: String::from_str(&e, "0.1.0"),
+            repo: String::from_str(&e, "https://github.com/zintarh/stellar-wrap-contract"),
+            description: String::from_str(&e, "Soulbound token registry for Stellar Wrap"),
+        }
     }
 
     /// Upgrade the contract WASM to a new version.

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -1,4 +1,13 @@
-use soroban_sdk::{contracttype, Address, BytesN, Symbol};
+use soroban_sdk::{contracttype, Address, BytesN, String, Symbol};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractInfo {
+    pub name: String,
+    pub version: String,
+    pub repo: String,
+    pub description: String,
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -234,6 +234,27 @@ fn test_token_metadata() {
     assert_eq!(client.symbol(), String::from_str(&env, "WRAP"));
 }
 
+// ─── Issue #56: contract_info tests ─────────────────────────────────────────
+
+#[test]
+fn test_contract_info_returns_correct_fields() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let info = client.contract_info();
+    assert_eq!(info.name, String::from_str(&env, "Stellar Wrap Registry"));
+    assert_eq!(info.version, String::from_str(&env, "0.1.0"));
+    assert_eq!(
+        info.repo,
+        String::from_str(&env, "https://github.com/zintarh/stellar-wrap-contract")
+    );
+    assert_eq!(
+        info.description,
+        String::from_str(&env, "Soulbound token registry for Stellar Wrap")
+    );
+}
+
 // ─── Issue #84: extend_ttl tests ────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
- Add ContractInfo struct (name, version, repo, description) to storage_types
- Add contract_info() public function returning project metadata
- Test: verifies all four fields return correct values

closes #56 