### PR TITLE
feat: add on chain comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ This smart contract provides the on-chain registry for Stellar Wrap records:
 - Archetype/persona assigned to the user (e.g., _"soroban_architect"_, _"defi_patron"_, _"diamond_hand"_)
 
 3.  **Query:** Anyone can call `get_wrap()` to retrieve a user's wrap record, enabling verification and display of on-chain personas.
-4.  **Soulbound:** Records are non-transferable (SBT), permanently linked to the user's Stellar address.
+4.  **Compare:** Anyone can call `compare_wraps()` to compare two users' visible wraps for the same period in one read.
+5.  **Soulbound:** Records are non-transferable (SBT), permanently linked to the user's Stellar address.
 
 ---
 
@@ -104,6 +105,8 @@ sequenceDiagram
     Note over Frontend,Contract: 5. Frontend reads data
     Frontend->>Contract: get_wrap(user, period)
     Contract-->>Frontend: WrapRecord {timestamp, data_hash, archetype, period}
+    Frontend->>Contract: compare_wraps(user_a, user_b, period)
+    Contract-->>Frontend: WrapComparison {user_a_wrap, user_b_wrap, both_have_wrap, same_archetype, period}
     Frontend->>Contract: balance_of(user)
     Contract-->>Frontend: wrap count
     Frontend->>Frontend: Display persona & stats
@@ -127,9 +130,14 @@ sequenceDiagram
 - ✅ Soulbound token (SBT) minting with authorization checks
 - ✅ Wrap record storage (timestamp, data hash, archetype)
 - ✅ Public query interface for retrieving wrap records
+- ✅ Public comparison interface for comparing two users' wraps
 - ✅ Event emission for minting actions
 - ✅ Prevention of duplicate wraps per user
 - ✅ Contract upgrade mechanism (admin-only WASM upgrade via `upgrade()`)
+
+## Privacy Note
+
+`compare_wraps(user_a, user_b, period)` is intentionally read-only and public, like `get_wrap`. That means it can reveal whether each user has a visible wrap for that period, and whether both users share the same archetype. Frontends should present this clearly, and if wrap visibility opt-out is enabled, opted-out users should resolve as `None` in comparisons rather than exposing their record.
 
 ### Upgrading the Contract
 
@@ -185,10 +193,13 @@ The mint reentrancy guard uses Soroban temporary storage, not persistent storage
 - `initialize(e: Env, admin: Address)` - Initialize contract with admin (callable once)
 - `mint_wrap(e: Env, to: Address, data_hash: BytesN<32>, archetype: Symbol)` - Mint a wrap record (admin only)
 - `get_wrap(e: Env, user: Address) -> Option<WrapRecord>` - Retrieve a user's wrap record
+- `compare_wraps(e: Env, user_a: Address, user_b: Address, period: u64) -> WrapComparison` - Compare two users' wraps for one period
+- `compare_total_wraps(e: Env, user_a: Address, user_b: Address) -> (u32, u32)` - Compare lifetime wrap totals
 
 ### Storage
 
 - `WrapRecord`: Contains `timestamp`, `data_hash`, and `archetype`
+- `WrapComparison`: Contains both users' wraps plus comparison booleans
 - `DataKey::Admin`: Stores the admin address
 - `DataKey::Wrap(Address)`: Maps user addresses to their wrap records
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,15 @@ use soroban_sdk::{
 };
 
 mod storage_types;
-use storage_types::{ContractInfo, DataKey, WrapRecord};
+use storage_types::{ContractInfo, DataKey, WrapComparison, WrapRecord, WrapRecordOption};
+
+fn get_visible_wrap(e: &Env, user: &Address, period: u64) -> Option<WrapRecord> {
+    // Centralize visibility rules for wrap reads so privacy changes such as opt-out can be
+    // enforced consistently across all public read APIs.
+    e.storage()
+        .persistent()
+        .get(&DataKey::Wrap(user.clone(), period))
+}
 
 soroban_sdk::contractmeta!(
     key = "Description",
@@ -325,7 +333,58 @@ impl StellarWrapContract {
     /// # Returns
     /// `Some(WrapRecord)` if a record exists, `None` otherwise.
     pub fn get_wrap(e: Env, user: Address, period: u64) -> Option<WrapRecord> {
-        e.storage().persistent().get(&DataKey::Wrap(user, period))
+        get_visible_wrap(&e, &user, period)
+    }
+
+    /// Compare two users' wrap records for the same period.
+    ///
+    /// This is a read-only helper for social features. It reveals whether each user has a
+    /// visible wrap for `period`, and if both do, whether they share the same archetype.
+    ///
+    /// Privacy note: calling this function can reveal wrap existence and archetype equality for
+    /// both users. If opt-out visibility controls are enabled, opted-out users should resolve
+    /// to `None` through the shared visibility helper.
+    pub fn compare_wraps(e: Env, user_a: Address, user_b: Address, period: u64) -> WrapComparison {
+        let user_a_wrap = get_visible_wrap(&e, &user_a, period);
+        let user_b_wrap = get_visible_wrap(&e, &user_b, period);
+
+        let both_have_wrap = user_a_wrap.is_some() && user_b_wrap.is_some();
+        let same_archetype = match (&user_a_wrap, &user_b_wrap) {
+            (Some(a), Some(b)) => a.archetype == b.archetype,
+            _ => false,
+        };
+
+        WrapComparison {
+            user_a_wrap: match user_a_wrap {
+                Some(wrap) => WrapRecordOption::Some(wrap),
+                None => WrapRecordOption::None,
+            },
+            user_b_wrap: match user_b_wrap {
+                Some(wrap) => WrapRecordOption::Some(wrap),
+                None => WrapRecordOption::None,
+            },
+            both_have_wrap,
+            same_archetype,
+            period,
+        }
+    }
+
+    /// Return lifetime wrap totals for two users in a single read.
+    ///
+    /// This is useful for lightweight leaderboard or profile comparisons.
+    pub fn compare_total_wraps(e: Env, user_a: Address, user_b: Address) -> (u32, u32) {
+        let user_a_total = e
+            .storage()
+            .persistent()
+            .get::<_, u32>(&DataKey::WrapCount(user_a))
+            .unwrap_or(0);
+        let user_b_total = e
+            .storage()
+            .persistent()
+            .get::<_, u32>(&DataKey::WrapCount(user_b))
+            .unwrap_or(0);
+
+        (user_a_total, user_b_total)
     }
 
     /// Return the total number of wrap records minted for a user (their SBT balance).

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -19,6 +19,33 @@ pub struct WrapRecord {
 }
 
 #[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WrapRecordOption {
+    Some(WrapRecord),
+    None,
+}
+
+impl WrapRecordOption {
+    pub fn is_some(&self) -> bool {
+        matches!(self, Self::Some(_))
+    }
+
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct WrapComparison {
+    pub user_a_wrap: WrapRecordOption,
+    pub user_b_wrap: WrapRecordOption,
+    pub both_have_wrap: bool,
+    pub same_archetype: bool,
+    pub period: u64,
+}
+
+#[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     /// Stores the Address of the admin

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,7 +11,7 @@ use soroban_sdk::{
 };
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use crate::storage_types::{DataKey, WrapRecord};
+use crate::storage_types::{DataKey, WrapRecord, WrapRecordOption};
 
 fn sign_payload(
     env: &Env,
@@ -704,6 +704,233 @@ fn test_get_latest_wrap_single_mint() {
     assert_eq!(latest.data_hash, hash);
 }
 
+// ─── Issue #138: compare_wraps tests ────────────────────────────────────────
+
+#[test]
+fn test_compare_wraps_both_users_have_wraps_same_archetype() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[40u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let period = 2026u64;
+    let archetype = symbol_short!("arch");
+    let hash_a = BytesN::from_array(&env, &[40u8; 32]);
+    let hash_b = BytesN::from_array(&env, &[41u8; 32]);
+
+    let sig_a = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user_a,
+        period,
+        &archetype,
+        &hash_a,
+    );
+    let sig_b = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user_b,
+        period,
+        &archetype,
+        &hash_b,
+    );
+
+    client.mint_wrap(&user_a, &period, &archetype, &hash_a, &sig_a);
+    client.mint_wrap(&user_b, &period, &archetype, &hash_b, &sig_b);
+
+    let comparison = client.compare_wraps(&user_a, &user_b, &period);
+    assert_eq!(comparison.period, period);
+    assert!(comparison.both_have_wrap);
+    assert!(comparison.same_archetype);
+    assert_eq!(
+        comparison.user_a_wrap,
+        WrapRecordOption::Some(client.get_wrap(&user_a, &period).unwrap())
+    );
+    assert_eq!(
+        comparison.user_b_wrap,
+        WrapRecordOption::Some(client.get_wrap(&user_b, &period).unwrap())
+    );
+}
+
+#[test]
+fn test_compare_wraps_both_users_have_wraps_different_archetypes() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[41u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let period = 2026u64;
+    let archetype_a = symbol_short!("arch");
+    let archetype_b = symbol_short!("defi");
+    let hash_a = BytesN::from_array(&env, &[42u8; 32]);
+    let hash_b = BytesN::from_array(&env, &[43u8; 32]);
+
+    let sig_a = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user_a,
+        period,
+        &archetype_a,
+        &hash_a,
+    );
+    let sig_b = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user_b,
+        period,
+        &archetype_b,
+        &hash_b,
+    );
+
+    client.mint_wrap(&user_a, &period, &archetype_a, &hash_a, &sig_a);
+    client.mint_wrap(&user_b, &period, &archetype_b, &hash_b, &sig_b);
+
+    let comparison = client.compare_wraps(&user_a, &user_b, &period);
+    assert!(comparison.both_have_wrap);
+    assert!(!comparison.same_archetype);
+    assert_eq!(
+        comparison.user_a_wrap,
+        WrapRecordOption::Some(client.get_wrap(&user_a, &period).unwrap())
+    );
+    assert_eq!(
+        comparison.user_b_wrap,
+        WrapRecordOption::Some(client.get_wrap(&user_b, &period).unwrap())
+    );
+}
+
+#[test]
+fn test_compare_wraps_one_user_has_wrap() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[42u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let period = 2026u64;
+    let archetype = symbol_short!("arch");
+    let hash_a = BytesN::from_array(&env, &[44u8; 32]);
+    let sig_a = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user_a,
+        period,
+        &archetype,
+        &hash_a,
+    );
+
+    client.mint_wrap(&user_a, &period, &archetype, &hash_a, &sig_a);
+
+    let comparison = client.compare_wraps(&user_a, &user_b, &period);
+    assert!(!comparison.both_have_wrap);
+    assert!(!comparison.same_archetype);
+    assert!(comparison.user_a_wrap.is_some());
+    assert!(comparison.user_b_wrap.is_none());
+}
+
+#[test]
+fn test_compare_wraps_neither_user_has_wrap() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[45u8; 32]);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+
+    let comparison = client.compare_wraps(&user_a, &user_b, &2026u64);
+    assert!(!comparison.both_have_wrap);
+    assert!(!comparison.same_archetype);
+    assert!(comparison.user_a_wrap.is_none());
+    assert!(comparison.user_b_wrap.is_none());
+}
+
+#[test]
+fn test_compare_total_wraps_returns_lifetime_counts() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[43u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let archetype = symbol_short!("arch");
+    let hash_a_1 = BytesN::from_array(&env, &[46u8; 32]);
+    let hash_a_2 = BytesN::from_array(&env, &[47u8; 32]);
+    let hash_b = BytesN::from_array(&env, &[48u8; 32]);
+
+    let sig_a_1 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user_a,
+        2024,
+        &archetype,
+        &hash_a_1,
+    );
+    let sig_a_2 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user_a,
+        2025,
+        &archetype,
+        &hash_a_2,
+    );
+    let sig_b = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user_b,
+        2026,
+        &archetype,
+        &hash_b,
+    );
+
+    client.mint_wrap(&user_a, &2024, &archetype, &hash_a_1, &sig_a_1);
+    client.mint_wrap(&user_a, &2025, &archetype, &hash_a_2, &sig_a_2);
+    client.mint_wrap(&user_b, &2026, &archetype, &hash_b, &sig_b);
+
+    let totals = client.compare_total_wraps(&user_a, &user_b);
+    assert_eq!(totals, (2, 1));
+}
+
 // ─── Issue #85: negative tests before initialize ────────────────────────────
 
 #[test]
@@ -1042,7 +1269,15 @@ fn test_mint_wrap_zero_hash_rejected() {
     let archetype = symbol_short!("arch");
     let period = 2024u64;
 
-    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &zero_hash);
+    let sig = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &zero_hash,
+    );
     // Must panic with InvalidDataHash
     client.mint_wrap(&user, &period, &archetype, &zero_hash, &sig);
 }
@@ -1068,7 +1303,15 @@ fn test_mint_wrap_non_zero_hash_succeeds() {
     let archetype = symbol_short!("arch");
     let period = 2024u64;
 
-    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &edge_hash);
+    let sig = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &edge_hash,
+    );
     client.mint_wrap(&user, &period, &archetype, &edge_hash, &sig);
 
     let wrap = client.get_wrap(&user, &period).unwrap();
@@ -1093,7 +1336,15 @@ fn test_mint_wrap_max_hash_succeeds() {
     let archetype = symbol_short!("arch");
     let period = 2024u64;
 
-    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &max_hash);
+    let sig = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &max_hash,
+    );
     client.mint_wrap(&user, &period, &archetype, &max_hash, &sig);
 
     let wrap = client.get_wrap(&user, &period).unwrap();
@@ -1129,7 +1380,15 @@ fn sign_update_payload(
     new_archetype: &Symbol,
     new_data_hash: &BytesN<32>,
 ) -> BytesN<64> {
-    sign_payload(env, signer, contract, user, period, new_archetype, new_data_hash)
+    sign_payload(
+        env,
+        signer,
+        contract,
+        user,
+        period,
+        new_archetype,
+        new_data_hash,
+    )
 }
 
 #[test]
@@ -1150,18 +1409,37 @@ fn test_update_wrap_succeeds_and_preserves_timestamp() {
     let archetype = symbol_short!("arch");
     let hash1 = BytesN::from_array(&env, &[41u8; 32]);
 
-    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
+    let sig1 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash1,
+    );
     client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
 
     let before = client.get_wrap(&user, &period).unwrap();
 
     let new_hash = BytesN::from_array(&env, &[99u8; 32]);
     let new_arch = symbol_short!("builder");
-    let sig2 = sign_update_payload(&env, &signing_key, &contract_id, &user, period, &new_arch, &new_hash);
+    let sig2 = sign_update_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &new_arch,
+        &new_hash,
+    );
     client.update_wrap(&user, &period, &new_hash, &new_arch, &sig2);
 
     let after = client.get_wrap(&user, &period).unwrap();
-    assert_eq!(after.timestamp, before.timestamp, "Original timestamp must be preserved");
+    assert_eq!(
+        after.timestamp, before.timestamp,
+        "Original timestamp must be preserved"
+    );
     assert_eq!(after.data_hash, new_hash);
     assert_eq!(after.archetype, new_arch);
     assert_eq!(after.period, period);
@@ -1184,12 +1462,28 @@ fn test_update_wrap_emits_update_event() {
     let period = 2025u64;
     let archetype = symbol_short!("arch");
     let hash1 = BytesN::from_array(&env, &[41u8; 32]);
-    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
+    let sig1 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash1,
+    );
     client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
 
     let new_hash = BytesN::from_array(&env, &[98u8; 32]);
     let new_arch = symbol_short!("defi");
-    let sig2 = sign_update_payload(&env, &signing_key, &contract_id, &user, period, &new_arch, &new_hash);
+    let sig2 = sign_update_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &new_arch,
+        &new_hash,
+    );
     client.update_wrap(&user, &period, &new_hash, &new_arch, &sig2);
 
     let events = env.events().all();
@@ -1224,7 +1518,15 @@ fn test_update_wrap_nonexistent_fails() {
 
     let new_hash = BytesN::from_array(&env, &[99u8; 32]);
     let new_arch = symbol_short!("arch");
-    let sig = sign_update_payload(&env, &signing_key, &contract_id, &user, 9999, &new_arch, &new_hash);
+    let sig = sign_update_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        9999,
+        &new_arch,
+        &new_hash,
+    );
     client.update_wrap(&user, &9999, &new_hash, &new_arch, &sig);
 }
 
@@ -1246,7 +1548,15 @@ fn test_update_wrap_requires_admin_auth() {
     let period = 2025u64;
     let archetype = symbol_short!("arch");
     let hash1 = BytesN::from_array(&env, &[41u8; 32]);
-    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
+    let sig1 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash1,
+    );
     client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
 
     // Reset auth — no admin auth mocked
@@ -1257,7 +1567,15 @@ fn test_update_wrap_requires_admin_auth() {
 
     let new_hash = BytesN::from_array(&env2, &[99u8; 32]);
     let new_arch = symbol_short!("arch");
-    let sig2 = sign_update_payload(&env2, &signing_key, &contract_id2, &user, period, &new_arch, &new_hash);
+    let sig2 = sign_update_payload(
+        &env2,
+        &signing_key,
+        &contract_id2,
+        &user,
+        period,
+        &new_arch,
+        &new_hash,
+    );
     // No auth mocked — must panic
     client2.update_wrap(&user, &period, &new_hash, &new_arch, &sig2);
 }
@@ -1280,10 +1598,26 @@ fn test_update_wrap_zero_hash_rejected() {
     let period = 2025u64;
     let archetype = symbol_short!("arch");
     let hash1 = BytesN::from_array(&env, &[41u8; 32]);
-    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
+    let sig1 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash1,
+    );
     client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
 
     let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
-    let sig2 = sign_update_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &zero_hash);
+    let sig2 = sign_update_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &zero_hash,
+    );
     client.update_wrap(&user, &period, &zero_hash, &archetype, &sig2);
 }


### PR DESCRIPTION
PR Description
Add on-chain wrap comparison helpers for social/profile features. This introduces compare_wraps(user_a, user_b, period) to return both users’ wrap data and convenience booleans, plus compare_total_wraps(user_a, user_b) for lifetime counts. It also adds unit coverage for both-users, one-user, neither-user, same-archetype, and different-archetype cases, and documents the privacy implications of public comparisons.
closes #138