### PR TITLE
Standardize Contract Error Handling and Eliminate Implicit Panics

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,14 @@ The mint reentrancy guard uses Soroban temporary storage, not persistent storage
 
 ### Error Codes
 
-| Code | Error |
-| --- | --- |
-| 1 | `AlreadyInitialized` |
-| 2 | `NotInitialized` |
-| 3 | `Unauthorized` |
-| 4 | `WrapAlreadyExists` |
-| 5 | `InvalidSignature` |
+| Code | Error | Description |
+| --- | --- | --- |
+| 1 | `AlreadyInitialized` | `initialize()` was called on a contract that is already initialized. |
+| 2 | `NotInitialized` | A function was called before `initialize()` has been run. |
+| 3 | `Unauthorized` | The caller is not authorized (not the admin, or reentrancy guard triggered). |
+| 4 | `WrapAlreadyExists` | A wrap record for this `(user, period)` pair already exists. |
+| 5 | `WrapNotFound` | The wrap record was not found. |
+| 6 | `InvalidSignature` | The provided Ed25519 signature is invalid or did not verify against the admin public key. |
+| 7 | `InvalidDataHash` | `data_hash` is all-zero bytes, which indicates missing or invalid data. |
+| 8 | `Overflow` | An arithmetic overflow occurred. |
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, panic_with_error, symbol_short, xdr::ToXdr, Address,
-    Bytes, BytesN, Env, String, Symbol,
+    Bytes, BytesN, Env, IntoVal, String, Symbol,
 };
 
 mod storage_types;
@@ -35,6 +35,8 @@ pub enum ContractError {
     InvalidSignature = 6,
     /// `data_hash` is all-zero bytes, which indicates missing or invalid data. (code 7)
     InvalidDataHash = 7,
+    /// An arithmetic overflow occurred. (code 8)
+    Overflow = 8,
 }
 
 #[contract]
@@ -156,8 +158,7 @@ impl StellarWrapContract {
         payload.append(&data_hash.clone().to_xdr(&e));
 
         // 5. Verify Admin Signature
-        e.crypto()
-            .ed25519_verify(&admin_pubkey, &payload, &signature);
+        verify_signature(&e, &admin_pubkey, &payload, &signature);
 
         // 6. Check Duplicates & Store Record
         let wrap_key = DataKey::Wrap(user.clone(), period);
@@ -182,9 +183,12 @@ impl StellarWrapContract {
         // 7. Update Balance
         let count_key = DataKey::WrapCount(user.clone());
         let current_count: u32 = e.storage().persistent().get(&count_key).unwrap_or(0);
+        let next_count = current_count
+            .checked_add(1)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::Overflow));
         e.storage()
             .persistent()
-            .set(&count_key, &(current_count + 1));
+            .set(&count_key, &next_count);
         e.storage()
             .persistent()
             .extend_ttl(&count_key, ttl_one_year, ttl_one_year);
@@ -259,8 +263,7 @@ impl StellarWrapContract {
         payload.append(&period.to_xdr(&e));
         payload.append(&new_archetype.clone().to_xdr(&e));
         payload.append(&new_data_hash.clone().to_xdr(&e));
-        e.crypto()
-            .ed25519_verify(&admin_pubkey, &payload, &signature);
+        verify_signature(&e, &admin_pubkey, &payload, &signature);
 
         let wrap_key = DataKey::Wrap(user.clone(), period);
         let existing: WrapRecord = e
@@ -469,9 +472,77 @@ impl StellarWrapContract {
         admin.require_auth();
         e.deployer().update_current_contract_wasm(new_wasm_hash);
     }
+
+    /// Verify an Ed25519 signature. Exposes the host `ed25519_verify` function
+    /// as a public contract method so that it can be invoked via `try_invoke_contract`
+    /// to catch panics.
+    pub fn verify_sig(
+        e: Env,
+        public_key: BytesN<32>,
+        payload: Bytes,
+        signature: BytesN<64>,
+    ) {
+        e.crypto()
+            .ed25519_verify(&public_key, &payload, &signature);
+    }
+}
+
+/// Helper to verify Ed25519 signature and handle panic explicitly.
+fn verify_signature(
+    e: &Env,
+    admin_pubkey: &BytesN<32>,
+    payload: &Bytes,
+    signature: &BytesN<64>,
+) {
+    // 1. Input validation first:
+    // Ensure public key is not all zeros
+    if admin_pubkey == &BytesN::from_array(e, &[0u8; 32]) {
+        panic_with_error!(e, ContractError::InvalidSignature);
+    }
+
+    // Ensure signature is not all zeros
+    if signature == &BytesN::from_array(e, &[0u8; 64]) {
+        panic_with_error!(e, ContractError::InvalidSignature);
+    }
+
+    // Validate signature S-value scalar range (Ed25519 malleability protection / range check)
+    let s_part = signature.slice(32..64);
+    const L: [u8; 32] = [
+        0xed, 0xd3, 0xf5, 0x5c, 0x1a, 0x63, 0x12, 0x58, 0xd6, 0x9c, 0xf7, 0xa2, 0xde, 0xf9, 0xde, 0x14,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10,
+    ];
+    let mut s_array = [0u8; 32];
+    s_part.copy_into_slice(&mut s_array);
+    
+    let mut is_s_valid = false;
+    for i in (0..32).rev() {
+        if s_array[i] < L[i] {
+            is_s_valid = true;
+            break;
+        } else if s_array[i] > L[i] {
+            break;
+        }
+    }
+    
+    if !is_s_valid {
+        panic_with_error!(e, ContractError::InvalidSignature);
+    }
+
+    // 2. Call verify_sig via try_invoke_contract to catch host-level verification panics
+    // and explicitly map them to ContractError::InvalidSignature.
+    let current_address = e.current_contract_address();
+    let func = Symbol::new(e, "verify_sig");
+    let args = (admin_pubkey.clone(), payload.clone(), signature.clone()).into_val(e);
+
+    let result = e.try_invoke_contract::<(), soroban_sdk::Error>(&current_address, &func, args);
+    match result {
+        Ok(Ok(())) => {}
+        _ => panic_with_error!(e, ContractError::InvalidSignature),
+    }
 }
 
 #[cfg(test)]
 mod security_test;
 #[cfg(test)]
 mod test;
+

--- a/src/test.rs
+++ b/src/test.rs
@@ -1287,3 +1287,115 @@ fn test_update_wrap_zero_hash_rejected() {
     let sig2 = sign_update_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &zero_hash);
     client.update_wrap(&user, &period, &zero_hash, &archetype, &sig2);
 }
+
+// ─── Tests for standardized signature verification errors (ContractError::InvalidSignature) ───
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_mint_with_invalid_signature_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let dummy_hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 2024u64;
+
+    // Construct a signature that won't pass (e.g. all zeros)
+    let invalid_signature = BytesN::from_array(&env, &[0u8; 64]);
+
+    client.mint_wrap(&user, &period, &archetype, &dummy_hash, &invalid_signature);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_mint_with_wrong_key_signature_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key_correct = SigningKey::from_bytes(&[1u8; 32]);
+    let signing_key_wrong = SigningKey::from_bytes(&[2u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key_correct.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let dummy_hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 2024u64;
+
+    // Sign with the wrong key
+    let wrong_signature = sign_payload(
+        &env,
+        &signing_key_wrong,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &dummy_hash,
+    );
+
+    client.mint_wrap(&user, &period, &archetype, &dummy_hash, &wrong_signature);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_update_with_wrong_key_signature_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key_correct = SigningKey::from_bytes(&[1u8; 32]);
+    let signing_key_wrong = SigningKey::from_bytes(&[2u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key_correct.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let dummy_hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 2024u64;
+
+    let signature = sign_payload(
+        &env,
+        &signing_key_correct,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &dummy_hash,
+    );
+    
+    // First mint succeeds
+    client.mint_wrap(&user, &period, &archetype, &dummy_hash, &signature);
+
+    let new_hash = BytesN::from_array(&env, &[43u8; 32]);
+    let new_archetype = symbol_short!("new");
+
+    // Sign update with wrong key
+    let wrong_signature = sign_payload(
+        &env,
+        &signing_key_wrong,
+        &contract_id,
+        &user,
+        period,
+        &new_archetype,
+        &new_hash,
+    );
+
+    client.update_wrap(&user, &period, &new_hash, &new_archetype, &wrong_signature);
+}
+


### PR DESCRIPTION
##closed #129 

The contract currently defines a ContractError enum with seven error variants, but several execution paths still rely on implicit panics and Soroban runtime errors that are not mapped to these standardized error codes. This results in inconsistent error handling and makes debugging more difficult.

Conduct a full audit of panic points within lib.rs, including runtime failures from ed25519_verify, storage access patterns using unwrap_or_else, and any other implicit panic sources. Refactor all user-facing failures to use panic_with_error! and return an appropriate ContractError variant. Where existing variants are insufficient, introduce new documented error codes.

Additionally, evaluate wrapping ed25519_verify to ensure signature verification failures consistently return ContractError::InvalidSignature rather than a Soroban runtime panic. Update error documentation, expand test coverage for newly explicit error paths, and ensure all existing tests continue to pass.

##Acceptance Criteria
      Audit and document all panic points in lib.rs.
      Map each panic path to an existing or newly introduced ContractError variant.
      Replace implicit panics with panic_with_error! where appropriate.
      Ensure signature verification failures return ContractError::InvalidSignature.
      Add Rust doc comments for all ContractError variants and codes.
      Update the error glossary (#118) to reflect standardized error handling.
      Maintain passing test coverage for existing functionality.
      Add tests for newly standardized error paths.

