### PR TITLE
Add on-chain wrap streak tracking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,23 @@ impl StellarWrapContract {
         migrated
     }
 
+    fn periods_are_consecutive(previous: u64, next: u64) -> bool {
+        let prev_year = previous / 100;
+        let prev_month = previous % 100;
+        let next_year = next / 100;
+        let next_month = next % 100;
+
+        if prev_month == 0 || prev_month > 12 || next_month == 0 || next_month > 12 {
+            return false;
+        }
+
+        if prev_month == 12 {
+            next_year == prev_year + 1 && next_month == 1
+        } else {
+            next_year == prev_year && next_month == prev_month + 1
+        }
+    }
+
     fn persist_wrap_record(
         e: &Env,
         user: Address,
@@ -435,12 +452,30 @@ impl StellarWrapContract {
 
         let latest_key = DataKey::LatestPeriod(user.clone());
         let current_latest: u64 = e.storage().persistent().get(&latest_key).unwrap_or(0);
+
+        let streak_key = DataKey::WrapStreak(user.clone());
+        let current_streak: u32 = e.storage().persistent().get(&streak_key).unwrap_or(0);
+        let next_streak = if period > current_latest {
+            if current_latest != 0 && Self::periods_are_consecutive(current_latest, period) {
+                current_streak.saturating_add(1)
+            } else {
+                1
+            }
+        } else {
+            current_streak
+        };
+
         if period > current_latest {
             e.storage().persistent().set(&latest_key, &period);
             e.storage()
                 .persistent()
                 .extend_ttl(&latest_key, ttl_one_year, ttl_one_year);
         }
+
+        e.storage().persistent().set(&streak_key, &next_streak);
+        e.storage()
+            .persistent()
+            .extend_ttl(&streak_key, ttl_one_year, ttl_one_year);
 
         e.events()
             .publish((symbol_short!("mint"), user, period), archetype);
@@ -584,6 +619,8 @@ impl StellarWrapContract {
                 .set(&count_key, &(current_count - 1));
         }
 
+        // Streak is not recalculated on revoke to avoid expensive on-chain scans.
+        // This means streak may temporarily remain stale after a removal.
         e.events()
             .publish((symbol_short!("revoke"), user, period), true);
     }
@@ -680,12 +717,28 @@ impl StellarWrapContract {
             e.storage().persistent().extend_ttl(&count_key, ttl, ttl);
         }
 
-        let latest_key = DataKey::LatestPeriod(user);
+        let latest_key = DataKey::LatestPeriod(user.clone());
         if e.storage().persistent().has(&latest_key) {
             e.storage().persistent().extend_ttl(&latest_key, ttl, ttl);
         }
 
+        let streak_key = DataKey::WrapStreak(user.clone());
+        if e.storage().persistent().has(&streak_key) {
+            e.storage().persistent().extend_ttl(&streak_key, ttl, ttl);
+        }
+
         e.storage().instance().extend_ttl(ttl, ttl);
+    }
+
+    /// Return the current consecutive wrap streak for a user.
+    pub fn get_streak(e: Env, user: Address) -> u32 {
+        if Self::user_is_opted_out(&e, &user) {
+            return 0;
+        }
+        e.storage()
+            .persistent()
+            .get::<_, u32>(&DataKey::WrapStreak(user))
+            .unwrap_or(0)
     }
 
     /// Return the current admin address, or `None` if the contract is not yet initialized.

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -46,6 +46,8 @@ pub enum DataKey {
     WrapCount(Address),
     /// Tracks the latest (highest) period minted for a user
     LatestPeriod(Address),
+    /// Tracks the current consecutive wrap streak for a user
+    WrapStreak(Address),
     /// Temporary, invocation-scoped reentrancy guard for mint flow
     MintGuard(Address),
     /// Merkle root for batch claims per period

--- a/src/test.rs
+++ b/src/test.rs
@@ -116,6 +116,121 @@ fn test_mint_emits_event() {
 }
 
 #[test]
+fn test_streak_after_first_mint_is_one() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[13u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let period = 202402u64;
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[1u8; 32]);
+    let signature = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash,
+    );
+
+    client.mint_wrap(&user, &period, &archetype, &hash, &signature);
+    assert_eq!(client.get_streak(&user), 1);
+}
+
+#[test]
+fn test_streak_increments_for_consecutive_months_and_year_boundary() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[14u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[2u8; 32]);
+
+    let signature_1 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        202412u64,
+        &archetype,
+        &hash,
+    );
+    client.mint_wrap(&user, &202412u64, &archetype, &hash, &signature_1);
+    assert_eq!(client.get_streak(&user), 1);
+
+    let signature_2 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        202501u64,
+        &archetype,
+        &hash,
+    );
+    client.mint_wrap(&user, &202501u64, &archetype, &hash, &signature_2);
+    assert_eq!(client.get_streak(&user), 2);
+}
+
+#[test]
+fn test_streak_resets_after_gap() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[15u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[3u8; 32]);
+
+    let signature_1 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        202501u64,
+        &archetype,
+        &hash,
+    );
+    client.mint_wrap(&user, &202501u64, &archetype, &hash, &signature_1);
+    assert_eq!(client.get_streak(&user), 1);
+
+    let signature_2 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        202503u64,
+        &archetype,
+        &hash,
+    );
+    client.mint_wrap(&user, &202503u64, &archetype, &hash, &signature_2);
+    assert_eq!(client.get_streak(&user), 1);
+}
+
+#[test]
 fn test_balance_of_and_count() {
     let env = Env::default();
     let contract_id = env.register_contract(None, StellarWrapContract);


### PR DESCRIPTION
closes #99 
closes #101 
closes #102 
closes #103 


Problem
There is no on-chain tracking of consecutive monthly wraps ("streaks"). Frontends that want to display streak badges (e.g., "6-month streak!") must compute this off-chain by scanning all periods, which is fragile and duplicative.

Context
DataKey::LatestPeriod(Address) tracks the highest period per user
Periods use a YYYYMM format (e.g., 202412, 202501)
No mechanism exists to check whether periods are consecutive
Streak tracking requires knowing the previous period to determine continuity
Suggested Implementation
// New DataKey:
WrapStreak(Address),  // persistent storage -> u32 (current consecutive months)

// In mint_wrap, after storing the record:
// 1. Read LatestPeriod before updating it
// 2. If new period == previous_period + 1 (handling Dec→Jan year rollover):
//      streak += 1
//    Else:
//      streak = 1
// 3. Store updated streak
Acceptance Criteria
 Add DataKey::WrapStreak(Address) to store current streak count
 Update mint_wrap to calculate and store streak based on period continuity
 Handle year boundary correctly: period 202412 → 202501 is consecutive
 Add get_streak(env, user) -> u32 public getter
 First wrap sets streak to 1
 Gap in periods resets streak to 1
 revoke_wrap does NOT recalculate streak (too expensive; document this limitation)
 Unit tests: consecutive mints increment streak, gap resets, year boundary works
 Unit test: streak after first mint is 1
 Set TTL on streak entry consistent with other persistent data

Adds DataKey::WrapStreak and on-chain streak tracking in mint_wrap. Includes get_streak getter, year-boundary consecutive period handling, and unit tests for first-mint streak, consecutive increments, and gap resets. Revoke_wrap does not recalculate streak to avoid expensive on-chain scans.