### PR TITLE
Add pause/unpause mechanism for emergency stops (#32)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub enum ContractError {
     InvalidMigration = 11,
     /// Storage deposit/budget exceeded (code 12)
     StorageDepositExceeded = 12,
+    /// Contract is paused and minting is disabled (code 13)
+    ContractPaused = 13,
 }
 
 
@@ -103,6 +105,49 @@ impl StellarWrapContract {
             (symbol_short!("admin"), symbol_short!("updated")),
             (current_admin, new_admin),
         );
+    }
+
+    /// Pause the contract to disable minting (admin-only).
+    ///
+    /// This is a circuit breaker mechanism that allows the admin to pause minting
+    /// in case of a discovered vulnerability while a fix is prepared.
+    ///
+    /// # Authorization
+    /// Requires authorization from the **admin**.
+    ///
+    /// # Panics
+    /// - [`ContractError::NotInitialized`] if the contract has not been initialized.
+    pub fn pause(e: Env) {
+        let admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+        admin.require_auth();
+        e.storage().instance().set(&DataKey::Paused, &true);
+
+        e.events()
+            .publish((symbol_short!("pause"), symbol_short!("status")), true);
+    }
+
+    /// Unpause the contract to re-enable minting (admin-only).
+    ///
+    /// # Authorization
+    /// Requires authorization from the **admin**.
+    ///
+    /// # Panics
+    /// - [`ContractError::NotInitialized`] if the contract has not been initialized.
+    pub fn unpause(e: Env) {
+        let admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+        admin.require_auth();
+        e.storage().instance().set(&DataKey::Paused, &false);
+
+        e.events()
+            .publish((symbol_short!("pause"), symbol_short!("status")), false);
     }
 
     /// Charge storage deposit units for a user before performing a persistent write.
@@ -201,6 +246,11 @@ impl StellarWrapContract {
         data_hash: BytesN<32>,
         signature: BytesN<64>,
     ) {
+        // 0. Circuit breaker: Check if contract is paused
+        if e.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            panic_with_error!(e, ContractError::ContractPaused);
+        }
+
         // 1. Security: Ensure the user actually signed this transaction
         user.require_auth();
 
@@ -294,6 +344,10 @@ impl StellarWrapContract {
         data_hash: BytesN<32>,
         proof: soroban_sdk::Vec<BytesN<32>>,
     ) {
+        // 0. Circuit breaker: Check if contract is paused
+        if e.storage().instance().get(&DataKey::Paused).unwrap_or(false) {
+            panic_with_error!(e, ContractError::ContractPaused);
+        }
 
         user.require_auth();
 

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -72,6 +72,8 @@ pub enum DataKey {
     MerkleClaimed(Address, u64),
     /// User privacy opt-out flag (persistent)
     UserOptOut(Address),
+    /// Circuit breaker pause flag (instance storage)
+    Paused,
 }
 
 /// Current schema version written by `initialize()` and advanced by `migrate()`.

--- a/src/test.rs
+++ b/src/test.rs
@@ -1781,3 +1781,220 @@ fn test_admin_can_revoke_opted_out_wrap() {
     client.revoke_wrap(&user, &period);
     assert_eq!(client.balance_of(&user), 0);
 }
+
+#[test]
+fn test_admin_can_pause_contract() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[70u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.pause();
+}
+
+#[test]
+fn test_admin_can_unpause_contract() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[71u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.pause();
+    client.unpause();
+}
+
+#[test]
+fn test_non_admin_cannot_pause() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[72u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+
+    env.mock_auths(&non_admin, &non_admin);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.pause();
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_minting_blocked_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[73u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.pause();
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[90u8; 32]);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_claiming_blocked_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[74u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.pause();
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[91u8; 32]);
+    let proof = soroban_sdk::Vec::new(&env);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.claim_wrap(&user, &period, &archetype, &hash, &proof);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_read_functions_work_when_paused() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[75u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[92u8; 32]);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+
+    client.pause();
+
+    // Read functions should still work
+    assert!(client.get_wrap(&user, &period).is_some());
+    assert_eq!(client.balance_of(&user), 1);
+    assert_eq!(client.get_streak(&user), 1);
+    assert!(client.get_latest_wrap(&user).is_some());
+}
+
+#[test]
+fn test_minting_resumes_after_unpause() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[76u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.pause();
+    client.unpause();
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[93u8; 32]);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+
+    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+    assert!(client.get_wrap(&user, &period).is_some());
+}
+
+#[test]
+fn test_pause_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[77u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.pause();
+
+    let events = env.events().all();
+    let last_event = events.last().expect("No events found");
+    let (_, topics, data) = last_event;
+
+    let event_topic: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let event_status: bool = data.try_into_val(&env).unwrap();
+
+    assert_eq!(event_topic, symbol_short!("pause"));
+    assert_eq!(event_status, true);
+}
+
+#[test]
+fn test_unpause_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[78u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.pause();
+    client.unpause();
+
+    let events = env.events().all();
+    let last_event = events.last().expect("No events found");
+    let (_, topics, data) = last_event;
+
+    let event_topic: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let event_status: bool = data.try_into_val(&env).unwrap();
+
+    assert_eq!(event_topic, symbol_short!("pause"));
+    assert_eq!(event_status, false);
+}
+


### PR DESCRIPTION
This PR implements issue #32 by adding a circuit breaker mechanism to pause/unpause minting in case of discovered vulnerabilities.

## Changes Made

### Storage
- Added `Paused` DataKey to the `DataKey` enum for circuit breaker functionality (instance storage)

### Error Handling
- Added `ContractPaused` error variant (code 13) to the `ContractError` enum

### Core Functions
- Implemented [pause()](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/lib.rs:109:4-130:5) function (admin-only) to disable minting
- Implemented [unpause()](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/lib.rs:132:4-150:5) function (admin-only) to re-enable minting
- Added pause check at the top of [mint_wrap()](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/lib.rs:211:4-312:5) function
- Added pause check at the top of [claim_wrap()](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/lib.rs:334:4-411:5) function

### Behavior
- Only admin can pause/unpause (requires admin authorization)
- Minting and claiming are blocked when paused (throws `ContractPaused` error)
- Read functions ([get_wrap](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/lib.rs:754:4-767:5), [balance_of](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/lib.rs:773:4-787:5), [get_streak](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/lib.rs:852:4-861:5), [get_latest_wrap](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/lib.rs:759:4-773:5), etc.) continue to work when paused
- Events are emitted on pause/unpause operations

### Tests
Added comprehensive test coverage:
- [test_admin_can_pause_contract](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/test.rs:1784:0-1798:1) - Verifies admin can pause
- [test_admin_can_unpause_contract](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/test.rs:1800:0-1815:1) - Verifies admin can unpause
- [test_non_admin_cannot_pause](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/test.rs:1817:0-1836:1) - Verifies non-admin cannot pause
- [test_minting_blocked_when_paused](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/test.rs:1838:0-1863:1) - Verifies minting blocked when paused
- [test_claiming_blocked_when_paused](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/test.rs:1865:0-1890:1) - Verifies claiming blocked when paused
- [test_read_functions_work_when_paused](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/test.rs:1892:0-1919:1) - Verifies reads still work when paused
- [test_minting_resumes_after_unpause](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/test.rs:1921:0-1945:1) - Verifies minting resumes after unpause
- [test_pause_emits_event](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/test.rs:1947:0-1971:1) - Verifies pause event emission
- [test_unpause_emits_event](cci:1://file:///c:/Users/TREASURE/OneDrive/Documents/WEB%20DEV/stellar-wrap-contract/src/test.rs:1973:0-1998:1) - Verifies unpause event emission

## Acceptance Criteria
✅ Add Paused DataKey and ContractPaused error
✅ Only admin can pause/unpause
✅ Minting blocked while paused, reads still work
✅ Tests for pause/unpause flow

Closes #32