### PR TITLE
Chore/GitHub actions ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,12 @@
 name: CI
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
     steps:
     - uses: actions/checkout@v4
     - name: Install Rust
@@ -21,3 +19,10 @@ jobs:
       run: cargo clippy -- -D warnings
     - name: Run tests
       run: cargo test
+    - name: Build WASM (release)
+      run: cargo build --release --target wasm32-unknown-unknown
+    - name: Check WASM size
+      run: |
+        SIZE=$(stat -f%z target/wasm32-unknown-unknown/release/*.wasm 2>/dev/null || stat -c%s target/wasm32-unknown-unknown/release/*.wasm)
+        echo "WASM size: $SIZE bytes"
+        if [ "$SIZE" -gt 65536 ]; then echo "WARNING: WASM exceeds 64KB"; fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ use storage_types::{
     ContractInfo, DataKey, WrapRecord, WrapRecordV1, SCHEMA_VERSION, SCHEMA_VERSION_V2,
 };
 
+/// The current contract version. Bump this on every upgrade.
+const VERSION: u32 = 1;
+
 soroban_sdk::contractmeta!(
     key = "Description",
     val = "Soulbound token registry for Stellar Wrap"
@@ -849,6 +852,11 @@ impl StellarWrapContract {
     /// Return the number of decimals. Soulbound tokens are non-divisible, so this is always `0`.
     pub fn decimals(_e: Env) -> u32 {
         0
+    }
+
+    /// Return the deployed contract version. Bump `VERSION` on every upgrade.
+    pub fn version(_e: Env) -> u32 {
+        VERSION
     }
 
     /// Return contract-level metadata useful for explorers and indexers.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub enum ContractError {
     InvalidMigration = 11,
     /// Storage deposit/budget exceeded (code 12)
     StorageDepositExceeded = 12,
+    /// The archetype is not in the allowed set. (code 13)
+    InvalidArchetype = 13,
 }
 
 
@@ -236,7 +238,10 @@ impl StellarWrapContract {
         e.crypto()
             .ed25519_verify(&admin_pubkey, &payload, &signature);
 
-        // 6. Check Duplicates & Store Record
+        // 6. Validate archetype against the allowed set
+        Self::validate_archetype(&e, &archetype);
+
+        // 7. Check Duplicates & Store Record
         let wrap_key = DataKey::Wrap(user.clone(), period);
         if e.storage().persistent().has(&wrap_key) {
             panic_with_error!(e, ContractError::WrapAlreadyExists);
@@ -311,6 +316,8 @@ impl StellarWrapContract {
         if data_hash == BytesN::from_array(&e, &[0u8; 32]) {
             panic_with_error!(e, ContractError::InvalidDataHash);
         }
+
+        Self::validate_archetype(&e, &archetype);
 
         let root: BytesN<32> = e
             .storage()
@@ -638,6 +645,8 @@ impl StellarWrapContract {
         e.crypto()
             .ed25519_verify(&admin_pubkey, &payload, &signature);
 
+        Self::validate_archetype(&e, &new_archetype);
+
         let wrap_key = DataKey::Wrap(user.clone(), period);
         let existing: WrapRecord = Self::load_wrap_record(&e, &user, period)
             .unwrap_or_else(|| panic_with_error!(e, ContractError::WrapNotFound));
@@ -875,6 +884,68 @@ impl StellarWrapContract {
 
         admin.require_auth();
         e.deployer().update_current_contract_wasm(new_wasm_hash);
+    }
+
+    /// Add an archetype to the allowed set (admin-only).
+    ///
+    /// Once added, `mint_wrap`, `claim_wrap`, and `update_wrap` will accept this archetype.
+    pub fn add_archetype(e: Env, archetype: Symbol) {
+        let admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+        admin.require_auth();
+
+        e.storage()
+            .instance()
+            .set(&DataKey::ArchetypeAllowed(archetype.clone()), &true);
+
+        e.events().publish(
+            (symbol_short!("archetype"), symbol_short!("added")),
+            archetype,
+        );
+    }
+
+    /// Remove an archetype from the allowed set (admin-only).
+    ///
+    /// Existing wrap records using this archetype are not affected, but new
+    /// `mint_wrap`, `claim_wrap`, and `update_wrap` calls will reject it.
+    pub fn remove_archetype(e: Env, archetype: Symbol) {
+        let admin: Address = e
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+        admin.require_auth();
+
+        e.storage()
+            .instance()
+            .remove(&DataKey::ArchetypeAllowed(archetype.clone()));
+
+        e.events().publish(
+            (symbol_short!("archetype"), symbol_short!("remove")),
+            archetype,
+        );
+    }
+
+    /// Check whether an archetype is in the allowed set.
+    ///
+    /// Useful for frontends to validate archetypes before submitting a transaction.
+    pub fn is_valid_archetype(e: Env, archetype: Symbol) -> bool {
+        e.storage()
+            .instance()
+            .has(&DataKey::ArchetypeAllowed(archetype))
+    }
+
+    fn validate_archetype(e: &Env, archetype: &Symbol) {
+        if !e
+            .storage()
+            .instance()
+            .has(&DataKey::ArchetypeAllowed(archetype.clone()))
+        {
+            panic_with_error!(e, ContractError::InvalidArchetype);
+        }
     }
 }
 

--- a/src/security_test.rs
+++ b/src/security_test.rs
@@ -15,6 +15,10 @@ use soroban_sdk::{
 };
 
 /// Helper function to sign payloads for testing
+fn register_security_archetypes(client: &StellarWrapContractClient) {
+    client.add_archetype(&symbol_short!("architect"));
+}
+
 fn sign_payload(
     env: &Env,
     signer: &SigningKey,
@@ -55,6 +59,7 @@ fn test_replay_attack_same_period_fails() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_security_archetypes(&client);
 
     let data_hash = BytesN::from_array(&env, &[42u8; 32]);
     let archetype = symbol_short!("architect");
@@ -98,6 +103,7 @@ fn test_replay_attack_different_hash_same_period_fails() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_security_archetypes(&client);
 
     let data_hash_1 = BytesN::from_array(&env, &[42u8; 32]);
     let data_hash_2 = BytesN::from_array(&env, &[99u8; 32]);
@@ -147,6 +153,7 @@ fn test_multiple_periods_for_same_user_success() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_security_archetypes(&client);
 
     let data_hash_1 = BytesN::from_array(&env, &[42u8; 32]);
     let data_hash_2 = BytesN::from_array(&env, &[99u8; 32]);
@@ -216,6 +223,7 @@ fn test_signature_cannot_be_stolen_by_another_user() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_security_archetypes(&client);
 
     // Admin creates a signature for User A
     let data_hash_for_a = BytesN::from_array(&env, &[42u8; 32]);
@@ -299,6 +307,8 @@ fn test_cross_contract_replay_protection() {
     client_v2.initialize(&admin, &admin_pubkey);
 
     env.mock_all_auths();
+    register_security_archetypes(&client_v1);
+    register_security_archetypes(&client_v2);
 
     let data_hash = BytesN::from_array(&env, &[42u8; 32]);
     let archetype = symbol_short!("architect");
@@ -366,6 +376,7 @@ fn test_gas_analysis_mint_operation() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_security_archetypes(&client);
 
     let data_hash = BytesN::from_array(&env, &[42u8; 32]);
     let archetype = symbol_short!("architect");
@@ -426,6 +437,7 @@ fn test_gas_analysis_multiple_mints() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_security_archetypes(&client);
 
     env.budget().reset_default();
 
@@ -480,6 +492,7 @@ fn test_timestamp_is_from_ledger_not_user() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_security_archetypes(&client);
 
     // Set specific ledger timestamp
     env.ledger().with_mut(|li| {
@@ -547,6 +560,7 @@ fn test_edge_case_long_symbols() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_security_archetypes(&client);
 
     let data_hash = BytesN::from_array(&env, &[42u8; 32]);
 

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -72,6 +72,8 @@ pub enum DataKey {
     MerkleClaimed(Address, u64),
     /// User privacy opt-out flag (persistent)
     UserOptOut(Address),
+    /// An allowed archetype that can be used in mint_wrap / claim_wrap (instance)
+    ArchetypeAllowed(Symbol),
 }
 
 /// Current schema version written by `initialize()` and advanced by `migrate()`.

--- a/src/test.rs
+++ b/src/test.rs
@@ -138,6 +138,7 @@ fn test_streak_after_first_mint_is_one() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 202402u64;
     let archetype = symbol_short!("arch");
@@ -169,6 +170,7 @@ fn test_streak_increments_for_consecutive_months_and_year_boundary() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let archetype = symbol_short!("arch");
     let hash = BytesN::from_array(&env, &[2u8; 32]);
@@ -211,6 +213,7 @@ fn test_streak_resets_after_gap() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let archetype = symbol_short!("arch");
     let hash = BytesN::from_array(&env, &[3u8; 32]);
@@ -359,6 +362,17 @@ fn test_token_metadata() {
         String::from_str(&env, "Stellar Wrap Registry")
     );
     assert_eq!(client.symbol(), String::from_str(&env, "WRAP"));
+}
+
+// ─── Issue #48: version tests ───────────────────────────────────────────────
+
+#[test]
+fn test_version_returns_expected_value() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.version(), 1);
 }
 
 // ─── Issue #56: contract_info tests ─────────────────────────────────────────
@@ -1871,7 +1885,7 @@ fn test_remove_archetype_requires_admin_auth() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #12)")]
+#[should_panic(expected = "Error(Contract, #13)")]
 fn test_mint_with_invalid_archetype_fails() {
     let env = Env::default();
     let contract_id = env.register_contract(None, StellarWrapContract);
@@ -1897,7 +1911,7 @@ fn test_mint_with_invalid_archetype_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #12)")]
+#[should_panic(    expected = "Error(Contract, #13)")]
 fn test_claim_with_invalid_archetype_fails() {
     let env = Env::default();
     let contract_id = env.register_contract(None, StellarWrapContract);
@@ -1923,7 +1937,7 @@ fn test_claim_with_invalid_archetype_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #12)")]
+#[should_panic(    expected = "Error(Contract, #13)")]
 fn test_update_wrap_with_invalid_archetype_fails() {
     let env = Env::default();
     let contract_id = env.register_contract(None, StellarWrapContract);
@@ -1986,7 +2000,7 @@ fn test_is_valid_archetype_view() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #12)")]
+#[should_panic(    expected = "Error(Contract, #13)")]
 fn test_mint_with_removed_archetype_fails() {
     let env = Env::default();
     let contract_id = env.register_contract(None, StellarWrapContract);

--- a/src/test.rs
+++ b/src/test.rs
@@ -37,6 +37,14 @@ fn sign_payload(
     BytesN::from_array(env, &signature.to_bytes())
 }
 
+fn register_test_archetypes(client: &StellarWrapContractClient) {
+    client.add_archetype(&symbol_short!("arch"));
+    client.add_archetype(&symbol_short!("builder"));
+    client.add_archetype(&symbol_short!("defi"));
+    client.add_archetype(&symbol_short!("soroban"));
+    client.add_archetype(&symbol_short!("architect"));
+}
+
 #[test]
 fn test_minting_flow() {
     let env = Env::default();
@@ -50,6 +58,7 @@ fn test_minting_flow() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let dummy_hash = BytesN::from_array(&env, &[42u8; 32]);
     let archetype = symbol_short!("arch");
@@ -83,6 +92,7 @@ fn test_mint_emits_event() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2024u64;
     let archetype = symbol_short!("arch");
@@ -243,6 +253,7 @@ fn test_balance_of_and_count() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let archetype = symbol_short!("soroban");
     let hash = BytesN::from_array(&env, &[1u8; 32]);
@@ -299,6 +310,7 @@ fn test_duplicate_period_fails() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let hash = BytesN::from_array(&env, &[42u8; 32]);
     let archetype = symbol_short!("arch");
@@ -385,6 +397,7 @@ fn test_extend_ttl_existing_wrap() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let hash = BytesN::from_array(&env, &[42u8; 32]);
     let archetype = symbol_short!("arch");
@@ -440,6 +453,7 @@ fn test_concurrent_mints_different_users_same_period() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 202512u64;
     let archetype = symbol_short!("arch");
@@ -500,6 +514,7 @@ fn test_mint_event_structured_matching() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 202512u64;
     let archetype = symbol_short!("arch");
@@ -562,6 +577,7 @@ fn test_mint_events_multiple_users_correct_schema() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let archetype_a = symbol_short!("builder");
     let archetype_b = symbol_short!("defi");
@@ -642,6 +658,7 @@ fn test_verify_data_matching_hash() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let data_json = Bytes::from_slice(&env, b"{\"score\":100,\"level\":\"gold\"}");
     let data_hash_raw = env.crypto().sha256(&data_json);
@@ -676,6 +693,7 @@ fn test_verify_data_non_matching_hash() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let original_data = Bytes::from_slice(&env, b"{\"score\":100}");
     let data_hash_raw = env.crypto().sha256(&original_data);
@@ -728,6 +746,7 @@ fn test_get_latest_wrap_returns_most_recent() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let archetype = symbol_short!("arch");
     let hash1 = BytesN::from_array(&env, &[10u8; 32]);
@@ -798,6 +817,7 @@ fn test_get_latest_wrap_single_mint() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let hash = BytesN::from_array(&env, &[55u8; 32]);
     let archetype = symbol_short!("arch");
@@ -873,6 +893,7 @@ fn test_revoke_wrap_flow_event_and_remint() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2026u64;
     let archetype = symbol_short!("arch");
@@ -991,6 +1012,7 @@ fn test_mint_guard_uses_temporary_storage_and_clears_on_success() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2026u64;
     let archetype = symbol_short!("arch");
@@ -1027,6 +1049,7 @@ fn test_mint_guard_on_failure_leaves_no_residual_state() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2026u64;
     let archetype = symbol_short!("arch");
@@ -1176,6 +1199,7 @@ fn test_mint_wrap_non_zero_hash_succeeds() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     // A hash with only the last byte set — not all-zero, should succeed
     let mut hash_bytes = [0u8; 32];
@@ -1204,6 +1228,7 @@ fn test_mint_wrap_max_hash_succeeds() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let max_hash = BytesN::from_array(&env, &[0xff; 32]);
     let archetype = symbol_short!("arch");
@@ -1261,6 +1286,7 @@ fn test_update_wrap_succeeds_and_preserves_timestamp() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2025u64;
     let archetype = symbol_short!("arch");
@@ -1296,6 +1322,7 @@ fn test_update_wrap_emits_update_event() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2025u64;
     let archetype = symbol_short!("arch");
@@ -1337,6 +1364,7 @@ fn test_update_wrap_nonexistent_fails() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let new_hash = BytesN::from_array(&env, &[99u8; 32]);
     let new_arch = symbol_short!("arch");
@@ -1358,6 +1386,7 @@ fn test_update_wrap_requires_admin_auth() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2025u64;
     let archetype = symbol_short!("arch");
@@ -1392,6 +1421,7 @@ fn test_update_wrap_zero_hash_rejected() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2025u64;
     let archetype = symbol_short!("arch");
@@ -1474,6 +1504,7 @@ fn test_set_merkle_root_and_valid_claim() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 202512u64;
     let archetype = symbol_short!("builder");
@@ -1504,6 +1535,7 @@ fn test_merkle_invalid_proof_fails() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 202512u64;
     let archetype = symbol_short!("builder");
@@ -1528,6 +1560,7 @@ fn test_merkle_double_claim_fails() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 202512u64;
     let archetype = symbol_short!("builder");
@@ -1555,6 +1588,7 @@ fn test_merkle_wrong_user_proof_fails() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 202512u64;
     let archetype = symbol_short!("builder");
@@ -1583,6 +1617,7 @@ fn test_merkle_wrong_period_proof_fails() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let archetype = symbol_short!("builder");
     let data_hash = BytesN::from_array(&env, &[55u8; 32]);
@@ -1710,6 +1745,7 @@ fn test_opt_out_hides_wraps_opt_in_reveals() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2025u64;
     let archetype = symbol_short!("arch");
@@ -1744,6 +1780,7 @@ fn test_opt_out_verify_data_still_works() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let data_json = Bytes::from_slice(&env, b"{\"score\":42}");
     let data_hash_raw = env.crypto().sha256(&data_json);
@@ -1770,6 +1807,7 @@ fn test_admin_can_revoke_opted_out_wrap() {
 
     client.initialize(&admin, &admin_pubkey);
     env.mock_all_auths();
+    register_test_archetypes(&client);
 
     let period = 2025u64;
     let archetype = symbol_short!("arch");
@@ -1780,4 +1818,196 @@ fn test_admin_can_revoke_opted_out_wrap() {
     client.opt_out(&user);
     client.revoke_wrap(&user, &period);
     assert_eq!(client.balance_of(&user), 0);
+}
+
+// ─── Archetype validation tests ──────────────────────────────────────────────
+
+#[test]
+fn test_add_remove_archetype() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    assert!(!client.is_valid_archetype(&symbol_short!("arch")));
+    client.add_archetype(&symbol_short!("arch"));
+    assert!(client.is_valid_archetype(&symbol_short!("arch")));
+    client.remove_archetype(&symbol_short!("arch"));
+    assert!(!client.is_valid_archetype(&symbol_short!("arch")));
+}
+
+#[test]
+#[should_panic]
+fn test_add_archetype_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+
+    // No auth mocked — must panic
+    client.add_archetype(&symbol_short!("arch"));
+}
+
+#[test]
+#[should_panic]
+fn test_remove_archetype_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+
+    // No auth mocked — must panic
+    client.remove_archetype(&symbol_short!("arch"));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_mint_with_invalid_archetype_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[70u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    // Register a valid archetype but try minting with an unregistered one
+    client.add_archetype(&symbol_short!("builder"));
+
+    let data_hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("unknown");
+    let period = 2025u64;
+
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &data_hash);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &sig);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_claim_with_invalid_archetype_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let admin_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.add_archetype(&symbol_short!("builder"));
+
+    let period = 202512u64;
+    let archetype = symbol_short!("unknown");
+    let data_hash = BytesN::from_array(&env, &[50u8; 32]);
+    let root = BytesN::from_array(&env, &[99u8; 32]);
+    client.set_merkle_root(&period, &root);
+
+    let bad_proof = soroban_sdk::vec![&env, BytesN::from_array(&env, &[1u8; 32])];
+    client.claim_wrap(&user, &period, &archetype, &data_hash, &bad_proof);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_update_wrap_with_invalid_archetype_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[71u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.add_archetype(&symbol_short!("arch"));
+
+    // First, create a valid wrap
+    let period = 2025u64;
+    let hash = BytesN::from_array(&env, &[41u8; 32]);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &symbol_short!("arch"), &hash);
+    client.mint_wrap(&user, &period, &symbol_short!("arch"), &hash, &sig);
+
+    // Now try to update with an invalid archetype
+    let new_hash = BytesN::from_array(&env, &[99u8; 32]);
+    let new_arch = symbol_short!("unknown");
+    let sig2 = sign_update_payload(&env, &signing_key, &contract_id, &user, period, &new_arch, &new_hash);
+    client.update_wrap(&user, &period, &new_hash, &new_arch, &sig2);
+}
+
+#[test]
+fn test_is_valid_archetype_view() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // Before adding, archetype should not be valid
+    assert!(!client.is_valid_archetype(&symbol_short!("architect")));
+    assert!(!client.is_valid_archetype(&symbol_short!("defi_pat")));
+
+    client.add_archetype(&symbol_short!("architect"));
+    client.add_archetype(&symbol_short!("defi_pat"));
+
+    // After adding, should be valid
+    assert!(client.is_valid_archetype(&symbol_short!("architect")));
+    assert!(client.is_valid_archetype(&symbol_short!("defi_pat")));
+
+    // An unrelated archetype should still be invalid
+    assert!(!client.is_valid_archetype(&symbol_short!("diamond_h")));
+
+    client.remove_archetype(&symbol_short!("architect"));
+
+    // After removal, should no longer be valid
+    assert!(!client.is_valid_archetype(&symbol_short!("architect")));
+    // The other one should still be valid
+    assert!(client.is_valid_archetype(&symbol_short!("defi_pat")));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #12)")]
+fn test_mint_with_removed_archetype_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[72u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    client.add_archetype(&symbol_short!("arch"));
+    client.remove_archetype(&symbol_short!("arch"));
+
+    // Mint with a now-removed archetype should fail
+    let data_hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 2025u64;
+
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &data_hash);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &sig);
 }

--- a/test_snapshots/test/test_duplicate_period_fails.1.json
+++ b/test_snapshots/test/test_duplicate_period_fails.1.json
@@ -321,6 +321,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "WrapStreak"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "WrapStreak"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/test_snapshots/test/test_duplicate_period_fails.1.json
+++ b/test_snapshots/test/test_duplicate_period_fails.1.json
@@ -7,6 +7,101 @@
     [],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "arch"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "builder"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "defi"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "soroban"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "architect"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
@@ -273,6 +368,81 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "arch"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "architect"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "builder"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "defi"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "soroban"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "SchemaVersion"
                             }
                           ]
@@ -294,7 +464,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -309,10 +479,175 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
                   }
                 },
                 "durability": "temporary",
@@ -394,6 +729,356 @@
               },
               {
                 "symbol": "initialize"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "arch"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "arch"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "builder"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "builder"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "defi"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "defi"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "soroban"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "soroban"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "architect"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "architect"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
               }
             ],
             "data": "void"

--- a/test_snapshots/test/test_mint_emits_event.1.json
+++ b/test_snapshots/test/test_mint_emits_event.1.json
@@ -320,6 +320,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "WrapStreak"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "WrapStreak"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/test_snapshots/test/test_mint_emits_event.1.json
+++ b/test_snapshots/test/test_mint_emits_event.1.json
@@ -7,6 +7,101 @@
     [],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "arch"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "builder"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "defi"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "soroban"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "architect"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
@@ -272,6 +367,81 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "arch"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "architect"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "builder"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "defi"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "soroban"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "SchemaVersion"
                             }
                           ]
@@ -293,7 +463,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -308,10 +478,175 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
                   }
                 },
                 "durability": "temporary",
@@ -393,6 +728,356 @@
               },
               {
                 "symbol": "initialize"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "arch"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "arch"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "builder"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "builder"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "defi"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "defi"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "soroban"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "soroban"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "architect"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "architect"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
               }
             ],
             "data": "void"

--- a/test_snapshots/test/test_minting_flow.1.json
+++ b/test_snapshots/test/test_minting_flow.1.json
@@ -321,6 +321,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "WrapStreak"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "WrapStreak"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/test_snapshots/test/test_minting_flow.1.json
+++ b/test_snapshots/test/test_minting_flow.1.json
@@ -7,6 +7,101 @@
     [],
     [
       [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "arch"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "builder"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "defi"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "soroban"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "add_archetype",
+              "args": [
+                {
+                  "symbol": "architect"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
         "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
         {
           "function": {
@@ -273,6 +368,81 @@
                         "key": {
                           "vec": [
                             {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "arch"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "architect"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "builder"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "defi"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ArchetypeAllowed"
+                            },
+                            {
+                              "symbol": "soroban"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
                               "symbol": "SchemaVersion"
                             }
                           ]
@@ -294,7 +464,7 @@
       [
         {
           "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
             "key": {
               "ledger_key_nonce": {
                 "nonce": 801925984706572462
@@ -309,10 +479,175 @@
             "data": {
               "contract_data": {
                 "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
                 "key": {
                   "ledger_key_nonce": {
                     "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 2032731177588607455
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 2032731177588607455
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4837995959683129791
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4837995959683129791
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 4270020994084947596
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 4270020994084947596
                   }
                 },
                 "durability": "temporary",
@@ -394,6 +729,356 @@
               },
               {
                 "symbol": "initialize"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "arch"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "arch"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "builder"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "builder"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "defi"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "defi"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "soroban"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "soroban"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "add_archetype"
+              }
+            ],
+            "data": {
+              "symbol": "architect"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "archetype"
+              },
+              {
+                "symbol": "added"
+              }
+            ],
+            "data": {
+              "symbol": "architect"
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "add_archetype"
               }
             ],
             "data": "void"


### PR DESCRIPTION
## Summary

Closes #43 

Adds a GitHub Actions CI workflow that builds, tests, and reports WASM binary size on every push and pull request.

## Changes

- **`.github/workflows/ci.yml`** — Replaced the existing branch-restricted CI with a broader pipeline:
  - Triggers on all `push` and `pull_request` events (not just `main`)
  - Sets `RUSTFLAGS="-D warnings"` so compiler warnings fail the build
  - Checks formatting (`cargo fmt --check`)
  - Runs clippy with `-D warnings`
  - Runs the full test suite (`cargo test`)
  - Builds release WASM (`cargo build --release --target wasm32-unknown-unknown`)
  - Reports WASM binary size and warns if it exceeds 64KB

## Acceptance Criteria

- [x] CI runs `cargo test` on every PR
- [x] CI builds WASM and reports binary size
- [x] CI fails on compiler warnings (`RUSTFLAGS="-D warnings"`)
