### PR TITLE
feat: implement archetype symbol validation, error code, and document…

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,29 @@ The mint reentrancy guard uses Soroban temporary storage, not persistent storage
 
 ### Error Codes
 
-| Code | Error |
-| --- | --- |
-| 1 | `AlreadyInitialized` |
-| 2 | `NotInitialized` |
-| 3 | `Unauthorized` |
-| 4 | `WrapAlreadyExists` |
-| 5 | `InvalidSignature` |
+| Code | Error | Description |
+| --- | --- | --- |
+| 1 | `AlreadyInitialized` | `initialize()` was called more than once |
+| 2 | `NotInitialized` | Function called before `initialize()` |
+| 3 | `Unauthorized` | Caller is not the admin / reentrancy detected |
+| 4 | `WrapAlreadyExists` | A wrap for this `(user, period)` already exists |
+| 5 | `WrapNotFound` | No wrap record found for the given `(user, period)` |
+| 6 | `InvalidSignature` | Ed25519 signature verification failed |
+| 7 | `InvalidDataHash` | `data_hash` is all-zero bytes |
+| 8 | `MerkleRootNotSet` | No merkle root published for this period |
+| 9 | `InvalidMerkleProof` | Merkle proof does not verify against stored root |
+| 10 | `MerkleAlreadyClaimed` | This `(user, period)` merkle claim already redeemed |
+| 11 | `InvalidMigration` | `migrate()` called with invalid version parameters |
+| 12 | `StorageDepositExceeded` | Storage deposit budget exceeded |
+| 13 | `InvalidArchetype` | Archetype is empty, too long (>20 chars), or contains invalid characters |
+
+### Archetype Format
+
+Archetype symbols must conform to the following rules:
+
+- **Allowed characters:** lowercase letters (`a-z`), digits (`0-9`), and underscore (`_`)
+- **Length:** 1–20 characters (inclusive)
+- **Examples:** `soroban_architect`, `defi_patron`, `diamond_hand`, `builder_99`
+
+Uppercase letters are rejected to prevent case-variant duplicates in storage.
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,8 +49,14 @@ pub enum ContractError {
     InvalidMigration = 11,
     /// Storage deposit/budget exceeded (code 12)
     StorageDepositExceeded = 12,
+    /// The archetype symbol is empty, too long, or contains invalid characters. (code 13)
+    InvalidArchetype = 13,
 }
 
+
+/// Maximum allowed length for archetype symbols (in characters).
+/// Accommodates all known archetypes (e.g. `"soroban_architect"` = 17 chars) with headroom.
+const MAX_ARCHETYPE_LEN: u32 = 20;
 
 #[contract]
 pub struct StellarWrapContract;
@@ -163,6 +169,37 @@ impl StellarWrapContract {
         }
     }
 
+    /// Validate that `archetype` is non-empty, at most [`MAX_ARCHETYPE_LEN`] characters,
+    /// and contains only lowercase alphanumeric + underscore characters (`[a-z0-9_]`).
+    ///
+    /// # Panics
+    /// - [`ContractError::InvalidArchetype`] if validation fails.
+    fn validate_archetype(e: &Env, archetype: &Symbol) {
+        // Serialize Symbol to XDR (ScVal::Symbol format):
+        //   bytes 0..3  = ScVal discriminant (0x0000000e for Symbol)
+        //   bytes 4..7  = string length (big-endian u32)
+        //   bytes 8..   = ASCII character data + 0-3 pad bytes
+        let xdr = archetype.to_xdr(e);
+        let b4 = xdr.get(4).unwrap_or(0) as u32;
+        let b5 = xdr.get(5).unwrap_or(0) as u32;
+        let b6 = xdr.get(6).unwrap_or(0) as u32;
+        let b7 = xdr.get(7).unwrap_or(0) as u32;
+        let len = (b4 << 24) | (b5 << 16) | (b6 << 8) | b7;
+
+        if len == 0 || len > MAX_ARCHETYPE_LEN {
+            panic_with_error!(e, ContractError::InvalidArchetype);
+        }
+        // Enforce lowercase alphanumeric + underscore only
+        for i in 0..len {
+            let c = xdr.get(i + 8).unwrap();
+            let valid = (c >= b'a' && c <= b'z')
+                || (c >= b'0' && c <= b'9')
+                || c == b'_';
+            if !valid {
+                panic_with_error!(e, ContractError::InvalidArchetype);
+            }
+        }
+    }
 
     /// Mint a soulbound wrap record for a user.
     ///
@@ -211,6 +248,9 @@ impl StellarWrapContract {
             panic_with_error!(e, ContractError::Unauthorized);
         }
         e.storage().temporary().set(&guard_key, &true);
+
+        // 1c. Validate archetype format
+        Self::validate_archetype(&e, &archetype);
 
         // 2. Verify initialization
         let admin_pubkey: BytesN<32> = e
@@ -302,6 +342,9 @@ impl StellarWrapContract {
             panic_with_error!(e, ContractError::Unauthorized);
         }
         e.storage().temporary().set(&guard_key, &true);
+
+        // Validate archetype format
+        Self::validate_archetype(&e, &archetype);
 
         e.storage()
             .instance()
@@ -617,6 +660,9 @@ impl StellarWrapContract {
             .get(&DataKey::Admin)
             .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
         admin.require_auth();
+
+        // Validate archetype format
+        Self::validate_archetype(&e, &new_archetype);
 
         let admin_pubkey: BytesN<32> = e
             .storage()

--- a/src/test.rs
+++ b/src/test.rs
@@ -1781,3 +1781,190 @@ fn test_admin_can_revoke_opted_out_wrap() {
     client.revoke_wrap(&user, &period);
     assert_eq!(client.balance_of(&user), 0);
 }
+
+// ─── Issue #120: archetype sanitization tests ───────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_mint_empty_archetype_rejected() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[70u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[1u8; 32]);
+    let period = 2025u64;
+    // Empty symbol — should be rejected
+    let archetype = Symbol::new(&env, "");
+
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+}
+
+#[test]
+fn test_mint_max_length_archetype_accepted() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[71u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[2u8; 32]);
+    let period = 2025u64;
+    // Exactly 20 characters — should succeed
+    let archetype = Symbol::new(&env, "soroban_architect_xx");
+
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+
+    let wrap = client.get_wrap(&user, &period).unwrap();
+    assert_eq!(wrap.archetype, archetype);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_mint_over_max_archetype_rejected() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[72u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[3u8; 32]);
+    let period = 2025u64;
+    // 21 characters — should be rejected
+    let archetype = Symbol::new(&env, "soroban_architect_xxx");
+
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_mint_archetype_uppercase_rejected() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[73u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[4u8; 32]);
+    let period = 2025u64;
+    // Uppercase letter — should be rejected
+    let archetype = Symbol::new(&env, "Builder");
+
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+}
+
+#[test]
+fn test_mint_archetype_valid_chars_accepted() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[74u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[5u8; 32]);
+    let period = 2025u64;
+    // Valid: lowercase + digits + underscore
+    let archetype = Symbol::new(&env, "defi_patron_99");
+
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+
+    let wrap = client.get_wrap(&user, &period).unwrap();
+    assert_eq!(wrap.archetype, archetype);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_claim_wrap_invalid_archetype_rejected() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[75u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[6u8; 32]);
+    let period = 2025u64;
+    // Empty archetype via claim_wrap — should be rejected
+    let archetype = Symbol::new(&env, "");
+    let root = BytesN::from_array(&env, &[99u8; 32]);
+    client.set_merkle_root(&period, &root);
+
+    let proof = soroban_sdk::vec![&env];
+    client.claim_wrap(&user, &period, &archetype, &hash, &proof);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_update_wrap_invalid_archetype_rejected() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[76u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    // First mint a valid wrap
+    let hash = BytesN::from_array(&env, &[7u8; 32]);
+    let period = 2025u64;
+    let valid_archetype = symbol_short!("builder");
+
+    let sig = sign_payload(
+        &env, &signing_key, &contract_id, &user, period, &valid_archetype, &hash,
+    );
+    client.mint_wrap(&user, &period, &valid_archetype, &hash, &sig);
+
+    // Now try updating with an uppercase archetype — should be rejected
+    let new_hash = BytesN::from_array(&env, &[8u8; 32]);
+    let invalid_archetype = Symbol::new(&env, "Builder");
+
+    let update_sig = sign_payload(
+        &env, &signing_key, &contract_id, &user, period, &invalid_archetype, &new_hash,
+    );
+    client.update_wrap(&user, &period, &new_hash, &invalid_archetype, &update_sig);
+}

--- a/test_snapshots/test/test_duplicate_period_fails.1.json
+++ b/test_snapshots/test/test_duplicate_period_fails.1.json
@@ -226,6 +226,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "WrapStreak"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "WrapStreak"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/test_snapshots/test/test_mint_emits_event.1.json
+++ b/test_snapshots/test/test_mint_emits_event.1.json
@@ -225,6 +225,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "WrapStreak"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "WrapStreak"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }

--- a/test_snapshots/test/test_minting_flow.1.json
+++ b/test_snapshots/test/test_minting_flow.1.json
@@ -226,6 +226,51 @@
         {
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "WrapStreak"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "WrapStreak"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u32": 1
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          6307200
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": "ledger_key_contract_instance",
             "durability": "persistent"
           }


### PR DESCRIPTION
Closes #120

## Summary

Adds contract-level validation for the `archetype` Symbol parameter across all write paths (`mint_wrap`, `claim_wrap`, `update_wrap`). This prevents storage abuse from excessively long or malformed archetype strings and provides clear, actionable error messages instead of opaque Soroban runtime panics.

## Problem

The `mint_wrap`, `claim_wrap`, and `update_wrap` functions accepted any `Symbol` as the `archetype` parameter without length or character validation. While Soroban's `Symbol` type enforces a 32-character max and restricts to `[a-zA-Z0-9_]`, the error messages for violations are opaque runtime errors. Additionally:

- No explicit length bound existed beyond the runtime's 32-char max, allowing unnecessarily large storage entries
- Uppercase variants (e.g., `"Builder"` vs `"builder"`) could create duplicate archetype keys in storage
- Empty archetypes were semantically invalid but accepted
- If archetype rarity tracking (#92) is added, unbounded archetypes would create unbounded storage keys

## Solution

### New error code

```rust
/// The archetype symbol is empty, too long, or contains invalid characters. (code 13)
InvalidArchetype = 13,
```

### Validation rules

| Rule | Constraint |
|------|-----------|
| Minimum length | 1 character |
| Maximum length | 20 characters (`MAX_ARCHETYPE_LEN`) |
| Allowed characters | `[a-z0-9_]` (lowercase only) |

### Implementation

A new private helper `validate_archetype()` parses the Symbol's XDR representation to extract the string length and validate each character byte. The validation is called early in all three write paths — before signature/proof verification — so invalid archetypes fail fast without wasting compute on cryptographic operations.

## Changes

### `src/lib.rs`

- Added `ContractError::InvalidArchetype = 13` error variant
- Added `MAX_ARCHETYPE_LEN = 20` constant
- Added `validate_archetype()` private helper using XDR byte-level inspection
- Inserted validation calls in:
  - `mint_wrap()` — after reentrancy guard, before payload construction
  - `claim_wrap()` — after reentrancy guard, before merkle verification
  - `update_wrap()` — after admin auth, before payload construction

### `src/test.rs`

Added 7 new tests under `// ─── Issue #120: archetype sanitization tests ───`:

| Test | Scenario | Expected |
|------|----------|----------|
| `test_mint_empty_archetype_rejected` | Empty symbol `""` | `Error(Contract, #13)` |
| `test_mint_max_length_archetype_accepted` | 20-char `"soroban_architect_xx"` | ✅ Success |
| `test_mint_over_max_archetype_rejected` | 21-char `"soroban_architect_xxx"` | `Error(Contract, #13)` |
| `test_mint_archetype_uppercase_rejected` | `"Builder"` (uppercase B) | `Error(Contract, #13)` |
| `test_mint_archetype_valid_chars_accepted` | `"defi_patron_99"` | ✅ Success |
| `test_claim_wrap_invalid_archetype_rejected` | Empty archetype via `claim_wrap` | `Error(Contract, #13)` |
| `test_update_wrap_invalid_archetype_rejected` | Uppercase archetype via `update_wrap` | `Error(Contract, #13)` |

### `README.md`

- Updated Error Codes table with all 13 error codes (previously only listed 1–5)
- Added new **Archetype Format** section documenting allowed characters and length constraints

## Design Decisions

### Why lowercase-only (`[a-z0-9_]`)?

All existing archetypes use lowercase (`"soroban_architect"`, `"defi_patron"`, `"diamond_hand"`). Restricting to lowercase prevents case-variant duplicates that would create separate storage entries (e.g., `"Builder"` vs `"builder"`). This is especially important if archetype rarity tracking is added later.

### Why `MAX_ARCHETYPE_LEN = 20`?

The longest known archetype is `"soroban_architect"` (17 chars). A limit of 20 provides reasonable headroom while being well below the runtime max of 32, reducing potential storage bloat.

### Why validate before signature verification?

Invalid archetypes should fail fast before the contract spends gas on expensive Ed25519 or merkle proof verification. This ordering also means the validation check consumes minimal resources on the rejection path.

### Why XDR byte-level parsing?

Soroban's `Symbol` type doesn't expose a `to_string()` or character iterator in the contract runtime. The implementation reads the Symbol's XDR serialization directly (4-byte discriminant + 4-byte length + ASCII bytes) to extract and validate each character. This approach works in `no_std` without additional dependencies.

## Testing

```
cargo test
```

```
test result: ok. 76 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.88s
```

All 76 tests pass — 69 existing (no regressions) + 7 new archetype validation tests.

## Checklist

- [x] `ContractError::InvalidArchetype` variant added (code 13)
- [x] `MAX_ARCHETYPE_LEN` constant added (20 characters)
- [x] Archetype validated in `mint_wrap` before signature verification
- [x] Archetype validated in `claim_wrap` before merkle verification
- [x] Archetype validated in `update_wrap` before signature verification
- [x] Empty archetype strings rejected
- [x] Over-max-length archetype strings rejected
- [x] Uppercase characters rejected
- [x] Valid characters (`a-z`, `0-9`, `_`) accepted
- [x] Unit tests cover all rejection and acceptance paths
- [x] README error codes table updated
- [x] Archetype format documented in README
- [x] All existing tests pass (no regressions)
