### PR TITLE
Add expiry_ledger to admin mint signatures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub enum ContractError {
     InvalidMigration = 11,
     /// Storage deposit/budget exceeded (code 12)
     StorageDepositExceeded = 12,
+    /// The admin signature has expired (expiry_ledger < current ledger sequence). (code 13)
+    SignatureExpired = 13,
 }
 
 
@@ -166,9 +168,11 @@ impl StellarWrapContract {
 
     /// Mint a soulbound wrap record for a user.
     ///
-    /// The backend generates a payload of `(contract_id ‖ user ‖ period ‖ archetype ‖ data_hash)`,
+    /// The backend generates a payload of
+    /// `(contract_id ‖ user ‖ period ‖ archetype ‖ data_hash ‖ expiry_ledger)`,
     /// signs it with the admin Ed25519 private key, and delivers the signature to the user.
-    /// The user then calls this function to claim their on-chain wrap record.
+    /// The user then calls this function to claim their on-chain wrap record before
+    /// `expiry_ledger` is reached.
     ///
     /// **Invariant:** The admin must issue at most one signature per `(user, period)` pair.
     /// Only one archetype can ever be stored for a given period; a second valid signature for
@@ -180,6 +184,8 @@ impl StellarWrapContract {
     /// - `period`: A `u64` identifier for the wrap period (e.g. `202412` for December 2024).
     /// - `archetype`: A short `Symbol` describing the user's persona (e.g. `"builder"`).
     /// - `data_hash`: SHA-256 hash of the off-chain JSON data. Must not be all-zero bytes.
+    /// - `expiry_ledger`: The ledger sequence number after which this signature is invalid.
+    ///   The current ledger sequence must be ≤ `expiry_ledger` for the mint to succeed.
     /// - `signature`: 64-byte Ed25519 signature from the admin over the canonical payload.
     ///
     /// # Returns
@@ -191,6 +197,7 @@ impl StellarWrapContract {
     /// # Panics
     /// - [`ContractError::NotInitialized`] if the contract has not been initialized.
     /// - [`ContractError::InvalidDataHash`] if `data_hash` is all-zero bytes.
+    /// - [`ContractError::SignatureExpired`] if the current ledger sequence exceeds `expiry_ledger`.
     /// - [`ContractError::InvalidSignature`] if the Ed25519 signature is invalid.
     /// - [`ContractError::WrapAlreadyExists`] if a wrap for `(user, period)` already exists.
     pub fn mint_wrap(
@@ -199,6 +206,7 @@ impl StellarWrapContract {
         period: u64,
         archetype: Symbol,
         data_hash: BytesN<32>,
+        expiry_ledger: u32,
         signature: BytesN<64>,
     ) {
         // 1. Security: Ensure the user actually signed this transaction
@@ -224,19 +232,25 @@ impl StellarWrapContract {
             panic_with_error!(e, ContractError::InvalidDataHash);
         }
 
-        // 4. Reconstruct payload: contract_id ‖ user ‖ period ‖ archetype ‖ data_hash
+        // 4. Check signature expiry before verifying it
+        if e.ledger().sequence() > expiry_ledger {
+            panic_with_error!(e, ContractError::SignatureExpired);
+        }
+
+        // 5. Reconstruct payload: contract_id ‖ user ‖ period ‖ archetype ‖ data_hash ‖ expiry_ledger
         let mut payload = Bytes::new(&e);
         payload.append(&e.current_contract_address().to_xdr(&e));
         payload.append(&user.clone().to_xdr(&e));
         payload.append(&period.to_xdr(&e));
         payload.append(&archetype.clone().to_xdr(&e));
         payload.append(&data_hash.clone().to_xdr(&e));
+        payload.append(&expiry_ledger.to_xdr(&e));
 
-        // 5. Verify Admin Signature
+        // 6. Verify Admin Signature
         e.crypto()
             .ed25519_verify(&admin_pubkey, &payload, &signature);
 
-        // 6. Check Duplicates & Store Record
+        // 7. Check Duplicates & Store Record
         let wrap_key = DataKey::Wrap(user.clone(), period);
         if e.storage().persistent().has(&wrap_key) {
             panic_with_error!(e, ContractError::WrapAlreadyExists);

--- a/src/security_test.rs
+++ b/src/security_test.rs
@@ -14,6 +14,9 @@ use soroban_sdk::{
     Address, Bytes, BytesN, Env, Symbol,
 };
 
+/// Expiry far in the future so these security tests never trip the expiry check.
+const NEVER_EXPIRES: u32 = u32::MAX;
+
 /// Helper function to sign payloads for testing
 fn sign_payload(
     env: &Env,
@@ -30,6 +33,7 @@ fn sign_payload(
     payload.append(&period.to_xdr(env));
     payload.append(&archetype.clone().to_xdr(env));
     payload.append(&data_hash.clone().to_xdr(env));
+    payload.append(&NEVER_EXPIRES.to_xdr(env));
 
     let mut out = [0u8; 512];
     let len = payload.len() as usize;
@@ -71,7 +75,7 @@ fn test_replay_attack_same_period_fails() {
     );
 
     // First mint - should succeed
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature);
 
     // Verify the wrap was created
     let wrap = client.get_wrap(&user, &period);
@@ -79,7 +83,7 @@ fn test_replay_attack_same_period_fails() {
 
     // Replay attack: Try to mint again with the exact same parameters
     // This should PANIC with WrapAlreadyExists error (#4)
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature);
 }
 
 /// Test 2: Replay Attack with Different Hash (but same period)
@@ -115,7 +119,7 @@ fn test_replay_attack_different_hash_same_period_fails() {
     );
 
     // First mint - should succeed
-    client.mint_wrap(&user, &period, &archetype, &data_hash_1, &signature_1);
+    client.mint_wrap(&user, &period, &archetype, &data_hash_1, &NEVER_EXPIRES, &signature_1);
 
     let signature_2 = sign_payload(
         &env,
@@ -129,7 +133,7 @@ fn test_replay_attack_different_hash_same_period_fails() {
 
     // Try to mint again for the same period with a different hash
     // This should still fail - period is already used
-    client.mint_wrap(&user, &period, &archetype, &data_hash_2, &signature_2);
+    client.mint_wrap(&user, &period, &archetype, &data_hash_2, &NEVER_EXPIRES, &signature_2);
 }
 
 /// Test 3: Multiple Valid Periods Work Correctly
@@ -186,9 +190,9 @@ fn test_multiple_periods_for_same_user_success() {
     );
 
     // All three should succeed
-    client.mint_wrap(&user, &period_1, &archetype, &data_hash_1, &signature_1);
-    client.mint_wrap(&user, &period_2, &archetype, &data_hash_2, &signature_2);
-    client.mint_wrap(&user, &period_3, &archetype, &data_hash_3, &signature_3);
+    client.mint_wrap(&user, &period_1, &archetype, &data_hash_1, &NEVER_EXPIRES, &signature_1);
+    client.mint_wrap(&user, &period_2, &archetype, &data_hash_2, &NEVER_EXPIRES, &signature_2);
+    client.mint_wrap(&user, &period_3, &archetype, &data_hash_3, &NEVER_EXPIRES, &signature_3);
 
     // Verify all three wraps exist
     assert!(client.get_wrap(&user, &period_1).is_some());
@@ -233,7 +237,7 @@ fn test_signature_cannot_be_stolen_by_another_user() {
     );
 
     // User A mints successfully
-    client.mint_wrap(&user_a, &period, &archetype, &data_hash_for_a, &signature_a);
+    client.mint_wrap(&user_a, &period, &archetype, &data_hash_for_a, &NEVER_EXPIRES, &signature_a);
 
     // Verify User A has the wrap
     let wrap_a = client.get_wrap(&user_a, &period);
@@ -258,6 +262,7 @@ fn test_signature_cannot_be_stolen_by_another_user() {
         &period_b,
         &archetype,
         &data_hash_for_b,
+        &NEVER_EXPIRES,
         &signature_b,
     );
 
@@ -315,7 +320,7 @@ fn test_cross_contract_replay_protection() {
     );
 
     // Mint successfully on V1
-    client_v1.mint_wrap(&user, &period, &archetype, &data_hash, &signature_v1);
+    client_v1.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature_v1);
 
     // Verify the wrap exists on V1
     let wrap_v1 = client_v1.get_wrap(&user, &period);
@@ -333,7 +338,7 @@ fn test_cross_contract_replay_protection() {
         &data_hash,
     );
 
-    client_v2.mint_wrap(&user, &period, &archetype, &data_hash, &signature_v2);
+    client_v2.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature_v2);
 
     // Verify both contracts have independent storage
     let wrap_v2 = client_v2.get_wrap(&user, &period);
@@ -385,7 +390,7 @@ fn test_gas_analysis_mint_operation() {
     env.budget().reset_default();
 
     // Perform the mint operation
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature);
 
     // Get budget consumption
     env.budget().print();
@@ -453,7 +458,7 @@ fn test_gas_analysis_multiple_mints() {
             &data_hash,
         );
 
-        client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+        client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature);
     }
 
     let cpu_insns = env.budget().cpu_instruction_cost();
@@ -500,7 +505,7 @@ fn test_timestamp_is_from_ledger_not_user() {
         &data_hash,
     );
 
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature);
 
     let wrap = client.get_wrap(&user, &period).unwrap();
 
@@ -523,7 +528,7 @@ fn test_timestamp_is_from_ledger_not_user() {
         &data_hash,
     );
 
-    client.mint_wrap(&user, &period_2, &archetype, &data_hash, &signature_2);
+    client.mint_wrap(&user, &period_2, &archetype, &data_hash, &NEVER_EXPIRES, &signature_2);
 
     let wrap_2 = client.get_wrap(&user, &period_2).unwrap();
     assert_eq!(
@@ -564,7 +569,7 @@ fn test_edge_case_long_symbols() {
         &data_hash,
     );
 
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature);
 
     let wrap = client.get_wrap(&user, &period);
     assert!(wrap.is_some(), "Should handle reasonably long symbols");
@@ -603,7 +608,7 @@ fn test_non_admin_cannot_mint() {
     );
 
     // This should panic because attacker is not authorized
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature);
 }
 
 // ─── Degenerate Ed25519 key/signature edge cases ────────────────────────────
@@ -633,7 +638,7 @@ fn test_mint_with_all_zero_pubkey_rejected() {
     let period = 202512u64;
     let signature = BytesN::from_array(&env, &[1u8; 64]);
 
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature);
 }
 
 /// All-ones (0xFF) pubkey — invalid curve point.
@@ -657,7 +662,7 @@ fn test_mint_with_all_ones_pubkey_rejected() {
     let period = 202512u64;
     let signature = BytesN::from_array(&env, &[1u8; 64]);
 
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &signature);
 }
 
 /// Valid pubkey but all-zero signature.
@@ -682,7 +687,7 @@ fn test_mint_with_all_zero_signature_rejected() {
     let period = 202512u64;
     let zero_sig = BytesN::from_array(&env, &[0u8; 64]);
 
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &zero_sig);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &zero_sig);
 }
 
 /// Valid pubkey but all-ones (0xFF) signature.
@@ -707,7 +712,7 @@ fn test_mint_with_all_ones_signature_rejected() {
     let period = 202512u64;
     let ones_sig = BytesN::from_array(&env, &[0xff; 64]);
 
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &ones_sig);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &ones_sig);
 }
 
 /// Valid pubkey but single-bit tampered signature.
@@ -744,5 +749,5 @@ fn test_mint_with_tampered_signature_rejected() {
     sig_bytes[0] ^= 0x01;
     let tampered_sig = BytesN::from_array(&env, &sig_bytes);
 
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &tampered_sig);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &NEVER_EXPIRES, &tampered_sig);
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -5,7 +5,7 @@ use super::*;
 use ed25519_dalek::{Signer, SigningKey};
 use soroban_sdk::{
     symbol_short,
-    testutils::{Address as _, Events},
+    testutils::{Address as _, Events, Ledger},
     xdr::ToXdr,
     Address, Bytes, BytesN, Env, IntoVal, String, Symbol, TryIntoVal,
 };
@@ -21,6 +21,7 @@ fn sign_payload(
     period: u64,
     archetype: &Symbol,
     data_hash: &BytesN<32>,
+    expiry_ledger: u32,
 ) -> BytesN<64> {
     let mut payload = Bytes::new(env);
     payload.append(&contract.to_xdr(env));
@@ -28,6 +29,7 @@ fn sign_payload(
     payload.append(&period.to_xdr(env));
     payload.append(&archetype.clone().to_xdr(env));
     payload.append(&data_hash.clone().to_xdr(env));
+    payload.append(&expiry_ledger.to_xdr(env));
 
     let mut out = [0u8; 512];
     let len = payload.len() as usize;
@@ -63,8 +65,9 @@ fn test_minting_flow() {
         period,
         &archetype,
         &dummy_hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &period, &archetype, &dummy_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &dummy_hash, &u32::MAX, &signature);
 
     let wrap = client.get_wrap(&user, &period).unwrap();
     assert_eq!(wrap.data_hash, dummy_hash);
@@ -95,9 +98,10 @@ fn test_mint_emits_event() {
         period,
         &archetype,
         &hash,
+        u32::MAX,
     );
 
-    client.mint_wrap(&user, &period, &archetype, &hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &hash, &u32::MAX, &signature);
 
     let events = env.events().all();
     let last_event = events.last().expect("No events found");
@@ -140,9 +144,10 @@ fn test_streak_after_first_mint_is_one() {
         period,
         &archetype,
         &hash,
+        u32::MAX,
     );
 
-    client.mint_wrap(&user, &period, &archetype, &hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &hash, &u32::MAX, &signature);
     assert_eq!(client.get_streak(&user), 1);
 }
 
@@ -171,8 +176,9 @@ fn test_streak_increments_for_consecutive_months_and_year_boundary() {
         202412u64,
         &archetype,
         &hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &202412u64, &archetype, &hash, &signature_1);
+    client.mint_wrap(&user, &202412u64, &archetype, &hash, &u32::MAX, &signature_1);
     assert_eq!(client.get_streak(&user), 1);
 
     let signature_2 = sign_payload(
@@ -183,8 +189,9 @@ fn test_streak_increments_for_consecutive_months_and_year_boundary() {
         202501u64,
         &archetype,
         &hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &202501u64, &archetype, &hash, &signature_2);
+    client.mint_wrap(&user, &202501u64, &archetype, &hash, &u32::MAX, &signature_2);
     assert_eq!(client.get_streak(&user), 2);
 }
 
@@ -213,8 +220,9 @@ fn test_streak_resets_after_gap() {
         202501u64,
         &archetype,
         &hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &202501u64, &archetype, &hash, &signature_1);
+    client.mint_wrap(&user, &202501u64, &archetype, &hash, &u32::MAX, &signature_1);
     assert_eq!(client.get_streak(&user), 1);
 
     let signature_2 = sign_payload(
@@ -225,8 +233,9 @@ fn test_streak_resets_after_gap() {
         202503u64,
         &archetype,
         &hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &202503u64, &archetype, &hash, &signature_2);
+    client.mint_wrap(&user, &202503u64, &archetype, &hash, &u32::MAX, &signature_2);
     assert_eq!(client.get_streak(&user), 1);
 }
 
@@ -255,8 +264,9 @@ fn test_balance_of_and_count() {
         2021,
         &archetype,
         &hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &2021, &archetype, &hash, &sig1);
+    client.mint_wrap(&user, &2021, &archetype, &hash, &u32::MAX, &sig1);
 
     let sig2 = sign_payload(
         &env,
@@ -266,8 +276,9 @@ fn test_balance_of_and_count() {
         2022,
         &archetype,
         &hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &2022, &archetype, &hash, &sig2);
+    client.mint_wrap(&user, &2022, &archetype, &hash, &u32::MAX, &sig2);
 
     assert_eq!(client.balance_of(&user), 2);
 }
@@ -312,10 +323,11 @@ fn test_duplicate_period_fails() {
         period,
         &archetype,
         &hash,
+        u32::MAX,
     );
 
-    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
-    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+    client.mint_wrap(&user, &period, &archetype, &hash, &u32::MAX, &sig);
+    client.mint_wrap(&user, &period, &archetype, &hash, &u32::MAX, &sig);
 }
 
 #[test]
@@ -398,8 +410,9 @@ fn test_extend_ttl_existing_wrap() {
         period,
         &archetype,
         &hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+    client.mint_wrap(&user, &period, &archetype, &hash, &u32::MAX, &sig);
 
     // Anyone can call extend_ttl — no auth required
     client.extend_ttl(&user, &period);
@@ -454,6 +467,7 @@ fn test_concurrent_mints_different_users_same_period() {
         period,
         &archetype,
         &hash_a,
+        u32::MAX,
     );
     let sig_b = sign_payload(
         &env,
@@ -463,11 +477,12 @@ fn test_concurrent_mints_different_users_same_period() {
         period,
         &archetype,
         &hash_b,
+        u32::MAX,
     );
 
     // Both mints for the same period should succeed
-    client.mint_wrap(&user_a, &period, &archetype, &hash_a, &sig_a);
-    client.mint_wrap(&user_b, &period, &archetype, &hash_b, &sig_b);
+    client.mint_wrap(&user_a, &period, &archetype, &hash_a, &u32::MAX, &sig_a);
+    client.mint_wrap(&user_b, &period, &archetype, &hash_b, &u32::MAX, &sig_b);
 
     // Records are independent
     let wrap_a = client.get_wrap(&user_a, &period).unwrap();
@@ -513,8 +528,9 @@ fn test_mint_event_structured_matching() {
         period,
         &archetype,
         &hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+    client.mint_wrap(&user, &period, &archetype, &hash, &u32::MAX, &sig);
 
     // Event schema: topics = (Symbol("mint"), Address, u64), data = Symbol
     let events = env.events().all();
@@ -578,6 +594,7 @@ fn test_mint_events_multiple_users_correct_schema() {
         period_a,
         &archetype_a,
         &hash_a,
+        u32::MAX,
     );
     let sig_b = sign_payload(
         &env,
@@ -587,10 +604,11 @@ fn test_mint_events_multiple_users_correct_schema() {
         period_b,
         &archetype_b,
         &hash_b,
+        u32::MAX,
     );
 
-    client.mint_wrap(&user_a, &period_a, &archetype_a, &hash_a, &sig_a);
-    client.mint_wrap(&user_b, &period_b, &archetype_b, &hash_b, &sig_b);
+    client.mint_wrap(&user_a, &period_a, &archetype_a, &hash_a, &u32::MAX, &sig_a);
+    client.mint_wrap(&user_b, &period_b, &archetype_b, &hash_b, &u32::MAX, &sig_b);
 
     let events = env.events().all();
 
@@ -657,8 +675,9 @@ fn test_verify_data_matching_hash() {
         period,
         &archetype,
         &data_hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &u32::MAX, &signature);
 
     assert!(client.verify_data(&user, &period, &data_json));
 }
@@ -691,8 +710,9 @@ fn test_verify_data_non_matching_hash() {
         period,
         &archetype,
         &data_hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &u32::MAX, &signature);
 
     let tampered_data = Bytes::from_slice(&env, b"{\"score\":999}");
     assert!(!client.verify_data(&user, &period, &tampered_data));
@@ -742,6 +762,7 @@ fn test_get_latest_wrap_returns_most_recent() {
         2022,
         &archetype,
         &hash1,
+        u32::MAX,
     );
     let sig2 = sign_payload(
         &env,
@@ -751,6 +772,7 @@ fn test_get_latest_wrap_returns_most_recent() {
         2024,
         &archetype,
         &hash2,
+        u32::MAX,
     );
     let sig3 = sign_payload(
         &env,
@@ -760,11 +782,12 @@ fn test_get_latest_wrap_returns_most_recent() {
         2023,
         &archetype,
         &hash3,
+        u32::MAX,
     );
 
-    client.mint_wrap(&user, &2022, &archetype, &hash1, &sig1);
-    client.mint_wrap(&user, &2024, &archetype, &hash2, &sig2);
-    client.mint_wrap(&user, &2023, &archetype, &hash3, &sig3);
+    client.mint_wrap(&user, &2022, &archetype, &hash1, &u32::MAX, &sig1);
+    client.mint_wrap(&user, &2024, &archetype, &hash2, &u32::MAX, &sig2);
+    client.mint_wrap(&user, &2023, &archetype, &hash3, &u32::MAX, &sig3);
 
     let latest = client.get_latest_wrap(&user).unwrap();
     assert_eq!(latest.period, 2024);
@@ -811,8 +834,9 @@ fn test_get_latest_wrap_single_mint() {
         period,
         &archetype,
         &hash,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+    client.mint_wrap(&user, &period, &archetype, &hash, &u32::MAX, &sig);
 
     let latest = client.get_latest_wrap(&user).unwrap();
     assert_eq!(latest.period, 2025);
@@ -834,7 +858,7 @@ fn test_mint_wrap_before_init_fails() {
     let archetype = symbol_short!("arch");
     let sig = BytesN::from_array(&env, &[0u8; 64]);
 
-    client.mint_wrap(&user, &2024, &archetype, &hash, &sig);
+    client.mint_wrap(&user, &2024, &archetype, &hash, &u32::MAX, &sig);
 }
 
 #[test]
@@ -887,8 +911,9 @@ fn test_revoke_wrap_flow_event_and_remint() {
         period,
         &archetype,
         &hash_1,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &period, &archetype, &hash_1, &sig_1);
+    client.mint_wrap(&user, &period, &archetype, &hash_1, &u32::MAX, &sig_1);
     assert_eq!(client.balance_of(&user), 1);
 
     client.revoke_wrap(&user, &period);
@@ -919,8 +944,9 @@ fn test_revoke_wrap_flow_event_and_remint() {
         period,
         &archetype,
         &hash_2,
+        u32::MAX,
     );
-    client.mint_wrap(&user, &period, &archetype, &hash_2, &sig_2);
+    client.mint_wrap(&user, &period, &archetype, &hash_2, &u32::MAX, &sig_2);
 
     let wrap = client.get_wrap(&user, &period).unwrap();
     assert_eq!(wrap.data_hash, hash_2);
@@ -1003,9 +1029,10 @@ fn test_mint_guard_uses_temporary_storage_and_clears_on_success() {
         period,
         &archetype,
         &data_hash,
+        u32::MAX,
     );
 
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &u32::MAX, &signature);
 
     let guard_key = DataKey::MintGuard(user.clone());
     env.as_contract(&contract_id, || {
@@ -1039,14 +1066,15 @@ fn test_mint_guard_on_failure_leaves_no_residual_state() {
         period,
         &archetype,
         &data_hash,
+        u32::MAX,
     );
 
     // First mint succeeds.
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &u32::MAX, &signature);
 
     // Second mint panics (duplicate).
     let duplicate = catch_unwind(AssertUnwindSafe(|| {
-        client.mint_wrap(&user, &period, &archetype, &data_hash, &signature)
+        client.mint_wrap(&user, &period, &archetype, &data_hash, &u32::MAX, &signature)
     }));
     assert!(duplicate.is_err());
 
@@ -1158,9 +1186,9 @@ fn test_mint_wrap_zero_hash_rejected() {
     let archetype = symbol_short!("arch");
     let period = 2024u64;
 
-    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &zero_hash);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &zero_hash, u32::MAX);
     // Must panic with InvalidDataHash
-    client.mint_wrap(&user, &period, &archetype, &zero_hash, &sig);
+    client.mint_wrap(&user, &period, &archetype, &zero_hash, &u32::MAX, &sig);
 }
 
 #[test]
@@ -1184,8 +1212,8 @@ fn test_mint_wrap_non_zero_hash_succeeds() {
     let archetype = symbol_short!("arch");
     let period = 2024u64;
 
-    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &edge_hash);
-    client.mint_wrap(&user, &period, &archetype, &edge_hash, &sig);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &edge_hash, u32::MAX);
+    client.mint_wrap(&user, &period, &archetype, &edge_hash, &u32::MAX, &sig);
 
     let wrap = client.get_wrap(&user, &period).unwrap();
     assert_eq!(wrap.data_hash, edge_hash);
@@ -1209,8 +1237,8 @@ fn test_mint_wrap_max_hash_succeeds() {
     let archetype = symbol_short!("arch");
     let period = 2024u64;
 
-    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &max_hash);
-    client.mint_wrap(&user, &period, &archetype, &max_hash, &sig);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &max_hash, u32::MAX);
+    client.mint_wrap(&user, &period, &archetype, &max_hash, &u32::MAX, &sig);
 
     let wrap = client.get_wrap(&user, &period).unwrap();
     assert_eq!(wrap.data_hash, max_hash);
@@ -1245,7 +1273,21 @@ fn sign_update_payload(
     new_archetype: &Symbol,
     new_data_hash: &BytesN<32>,
 ) -> BytesN<64> {
-    sign_payload(env, signer, contract, user, period, new_archetype, new_data_hash)
+    // `update_wrap` signs over contract ‖ user ‖ period ‖ archetype ‖ data_hash
+    // (no expiry_ledger), so we build the payload directly here.
+    let mut payload = Bytes::new(env);
+    payload.append(&contract.to_xdr(env));
+    payload.append(&user.clone().to_xdr(env));
+    payload.append(&period.to_xdr(env));
+    payload.append(&new_archetype.clone().to_xdr(env));
+    payload.append(&new_data_hash.clone().to_xdr(env));
+
+    let mut out = [0u8; 512];
+    let len = payload.len() as usize;
+    payload.copy_into_slice(&mut out[..len]);
+
+    let signature = signer.sign(&out[..len]);
+    BytesN::from_array(env, &signature.to_bytes())
 }
 
 #[test]
@@ -1266,8 +1308,8 @@ fn test_update_wrap_succeeds_and_preserves_timestamp() {
     let archetype = symbol_short!("arch");
     let hash1 = BytesN::from_array(&env, &[41u8; 32]);
 
-    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
-    client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
+    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1, u32::MAX);
+    client.mint_wrap(&user, &period, &archetype, &hash1, &u32::MAX, &sig1);
 
     let before = client.get_wrap(&user, &period).unwrap();
 
@@ -1300,8 +1342,8 @@ fn test_update_wrap_emits_update_event() {
     let period = 2025u64;
     let archetype = symbol_short!("arch");
     let hash1 = BytesN::from_array(&env, &[41u8; 32]);
-    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
-    client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
+    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1, u32::MAX);
+    client.mint_wrap(&user, &period, &archetype, &hash1, &u32::MAX, &sig1);
 
     let new_hash = BytesN::from_array(&env, &[98u8; 32]);
     let new_arch = symbol_short!("defi");
@@ -1362,8 +1404,8 @@ fn test_update_wrap_requires_admin_auth() {
     let period = 2025u64;
     let archetype = symbol_short!("arch");
     let hash1 = BytesN::from_array(&env, &[41u8; 32]);
-    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
-    client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
+    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1, u32::MAX);
+    client.mint_wrap(&user, &period, &archetype, &hash1, &u32::MAX, &sig1);
 
     // Reset auth — no admin auth mocked
     let env2 = Env::default();
@@ -1396,8 +1438,8 @@ fn test_update_wrap_zero_hash_rejected() {
     let period = 2025u64;
     let archetype = symbol_short!("arch");
     let hash1 = BytesN::from_array(&env, &[41u8; 32]);
-    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1);
-    client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
+    let sig1 = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash1, u32::MAX);
+    client.mint_wrap(&user, &period, &archetype, &hash1, &u32::MAX, &sig1);
 
     let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
     let sig2 = sign_update_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &zero_hash);
@@ -1714,8 +1756,8 @@ fn test_opt_out_hides_wraps_opt_in_reveals() {
     let period = 2025u64;
     let archetype = symbol_short!("arch");
     let hash = BytesN::from_array(&env, &[80u8; 32]);
-    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
-    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash, u32::MAX);
+    client.mint_wrap(&user, &period, &archetype, &hash, &u32::MAX, &sig);
 
     assert!(client.get_wrap(&user, &period).is_some());
     assert!(!client.is_opted_out(&user));
@@ -1750,8 +1792,8 @@ fn test_opt_out_verify_data_still_works() {
     let data_hash = BytesN::from_array(&env, &data_hash_raw.to_array());
     let archetype = symbol_short!("arch");
     let period = 2025u64;
-    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &data_hash);
-    client.mint_wrap(&user, &period, &archetype, &data_hash, &sig);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &data_hash, u32::MAX);
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &u32::MAX, &sig);
 
     client.opt_out(&user);
     assert!(client.verify_data(&user, &period, &data_json));
@@ -1774,10 +1816,124 @@ fn test_admin_can_revoke_opted_out_wrap() {
     let period = 2025u64;
     let archetype = symbol_short!("arch");
     let hash = BytesN::from_array(&env, &[81u8; 32]);
-    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
-    client.mint_wrap(&user, &period, &archetype, &hash, &sig);
+    let sig = sign_payload(&env, &signing_key, &contract_id, &user, period, &archetype, &hash, u32::MAX);
+    client.mint_wrap(&user, &period, &archetype, &hash, &u32::MAX, &sig);
 
     client.opt_out(&user);
     client.revoke_wrap(&user, &period);
     assert_eq!(client.balance_of(&user), 0);
+}
+
+// ─── Signature expiry tests ─────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #13)")]
+fn test_mint_wrap_expired_signature_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[90u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    // Advance the ledger past the signature's expiry window.
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[90u8; 32]);
+    let expiry_ledger = 50u32; // already in the past relative to sequence 100
+
+    let sig = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash,
+        expiry_ledger,
+    );
+    // Must panic with SignatureExpired (#13).
+    client.mint_wrap(&user, &period, &archetype, &hash, &expiry_ledger, &sig);
+}
+
+#[test]
+fn test_mint_wrap_at_expiry_ledger_succeeds() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[91u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[91u8; 32]);
+    // Boundary: current sequence == expiry_ledger. The check is strictly greater,
+    // so the mint at exactly the expiry ledger is still valid.
+    let expiry_ledger = 100u32;
+
+    let sig = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash,
+        expiry_ledger,
+    );
+    client.mint_wrap(&user, &period, &archetype, &hash, &expiry_ledger, &sig);
+
+    let wrap = client.get_wrap(&user, &period).unwrap();
+    assert_eq!(wrap.data_hash, hash);
+}
+
+#[test]
+#[should_panic]
+fn test_mint_wrap_expiry_mismatch_invalidates_signature() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[92u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    env.ledger().with_mut(|li| li.sequence_number = 100);
+
+    let period = 2025u64;
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[92u8; 32]);
+
+    // Admin signs for expiry 200, but the caller submits a different (still
+    // non-expired) expiry 300. The payloads differ, so verification must fail.
+    let sig = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash,
+        200u32,
+    );
+    client.mint_wrap(&user, &period, &archetype, &hash, &300u32, &sig);
 }


### PR DESCRIPTION
## Summary

Admin mint signatures previously had no expiry — once signed, a `mint_wrap` signature was valid forever. A leaked-but-unsubmitted signature could be used at any future time. This adds an `expiry_ledger` to the signed payload so each
signature is only valid within a bounded ledger window.

## Changes

- `mint_wrap` now takes an `expiry_ledger: u32` parameter, included in the Ed25519 signed payload (`contract ‖ user ‖ period ‖ archetype ‖ data_hash ‖ expiry_ledger`).
- Reject expired signatures with a new `SignatureExpired` error when `ledger().sequence() > expiry_ledger`, checked before signature verification.
- Threaded `expiry_ledger` through all existing tests in `test.rs` and `security_test.rs`.
- `update_wrap`'s payload is intentionally unchanged (no expiry), so its test helper builds the payload directly.

## Tests added

- `test_mint_wrap_expired_signature_fails` — past-expiry mint panics.
- `test_mint_wrap_at_expiry_ledger_succeeds` — boundary (`sequence == expiry_ledger`) is allowed.
- `test_mint_wrap_expiry_mismatch_invalidates_signature` — submitting a different expiry than was signed fails verification.

Closes: #61 