### PR TITLE
feat: add has_wrap, integration test script, updated Makefile and sec…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,84 @@
-build:
-	soroban contract build
+.PHONY: build test fmt fmt-check lint clean deploy-testnet wasm-build docker-build docker-build-verify
 
+# ── Build ────────────────────────────────────────────────────────────────────
+
+## build: Compile the contract to WASM (release profile, wasm32 target)
+build: wasm-build
+
+## wasm-build: Explicit WASM release build (output: target/wasm32-unknown-unknown/release/*.wasm)
+wasm-build:
+	cargo build --release --target wasm32-unknown-unknown
+
+## soroban-build: Build via the Stellar CLI (alternative to cargo build --target wasm32)
+soroban-build:
+	stellar contract build
+
+# ── Test ─────────────────────────────────────────────────────────────────────
+
+## test: Run all unit and integration tests
 test:
 	cargo test
 
+## test-verbose: Run all tests with stdout output (useful for gas analysis)
+test-verbose:
+	cargo test -- --nocapture --test-threads=1
+
+# ── Format ───────────────────────────────────────────────────────────────────
+
+## fmt: Auto-format source code with rustfmt
 fmt:
 	cargo fmt
 
+## fmt-check: Check formatting without modifying files (CI-safe)
+fmt-check:
+	cargo fmt --check
+
+# ── Lint ─────────────────────────────────────────────────────────────────────
+
+## lint: Run clippy and treat all warnings as errors
+lint:
+	cargo clippy -- -D warnings
+
+# ── Deploy ───────────────────────────────────────────────────────────────────
+
+## deploy-testnet: Build and deploy the contract to Stellar testnet.
+##   Requires: stellar CLI, STELLAR_DEPLOYER_SECRET env var set.
+##   Usage: make deploy-testnet
+##   Optional: CONTRACT_ID=<id> to upgrade an existing contract instead of deploying fresh.
+deploy-testnet: wasm-build
+	@if [ -n "$(CONTRACT_ID)" ]; then \
+		echo "Upgrading existing contract $(CONTRACT_ID)…"; \
+		stellar contract upload \
+			--wasm target/wasm32-unknown-unknown/release/stellar_wrap_contract.wasm \
+			--network testnet \
+			--source "$(STELLAR_DEPLOYER_SECRET)"; \
+	else \
+		echo "Deploying new contract to testnet…"; \
+		stellar contract deploy \
+			--wasm target/wasm32-unknown-unknown/release/stellar_wrap_contract.wasm \
+			--network testnet \
+			--source "$(STELLAR_DEPLOYER_SECRET)"; \
+	fi
+
+# ── Clean ────────────────────────────────────────────────────────────────────
+
+## clean: Remove build artifacts
 clean:
 	cargo clean
 
+# ── Docker ───────────────────────────────────────────────────────────────────
+
+## docker-build: Build the contract inside Docker for reproducible WASM output
 docker-build:
 	docker build -t stellar-wrap-contract .
 
+## docker-build-verify: Build in Docker and print SHA-256 of the WASM artifact
 docker-build-verify:
 	docker build -t stellar-wrap-contract-verify .
 	docker run --rm stellar-wrap-contract-verify sha256sum /contract/target/wasm32-unknown-unknown/release/stellar_wrap_contract.wasm
+
+# ── Help ─────────────────────────────────────────────────────────────────────
+
+## help: List all available make targets with descriptions
+help:
+	@grep -E '^## ' Makefile | sed 's/## /  /'

--- a/README.md
+++ b/README.md
@@ -529,3 +529,63 @@ Every deployment writes `contract-id.txt` as a GitHub Actions artifact and adds 
 
 ### Error Codes
 
+
+
+## Manual Testnet Integration Test
+
+All unit tests use `Env::default()` (mock environment). The script
+`tests/integration_testnet.sh` provides an end-to-end smoke test that deploys
+the contract to a real Stellar testnet node, calls every major entry point, and
+verifies the results.
+
+> **Not run in CI by default.** Run this manually before a mainnet deployment or
+> after significant changes to the contract.
+
+### Prerequisites
+
+- Stellar CLI installed — see [developers.stellar.org](https://developers.stellar.org/docs/tools/stellar-cli)
+- A funded Stellar testnet keypair (`stellar keys generate --network testnet`)
+- Rust with the `wasm32-unknown-unknown` target
+
+### Running the script
+
+```bash
+# Required
+export STELLAR_DEPLOYER_SECRET=SXXXXXXX...       # funded testnet secret key
+export STELLAR_ADMIN_PUBKEY=aabbccdd...          # 64-hex Ed25519 public key
+
+# Optional: provide a real admin Ed25519 signature to test the full mint path
+export STELLAR_MINT_SIGNATURE=<128-hex sig>      # sign the canonical payload
+
+bash tests/integration_testnet.sh
+```
+
+### What it does
+
+| Step | Action | Verified |
+|------|--------|---------|
+| 1 | `cargo build --release --target wasm32-unknown-unknown` | WASM artifact exists |
+| 2 | `stellar contract deploy` | Contract ID returned |
+| 3 | `initialize(admin, admin_pubkey)` | No error |
+| 4 | `add_archetype` + `mint_wrap` (when signature provided) | No error |
+| 5 | `get_wrap(user, period)` | Returns `WrapRecord` |
+| 6 | `has_wrap(user, period)` | Returns `true` |
+| 7 | `balance_of(user)` | Returns `1` |
+| 8 | Cleanup local contract-id file | File removed |
+
+### Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `STELLAR_DEPLOYER_SECRET` | Yes | Secret key for the funded deployer account |
+| `STELLAR_ADMIN_PUBKEY` | Yes | 64-hex Ed25519 public key passed to `initialize()` |
+| `STELLAR_MINT_SIGNATURE` | No | 128-hex Ed25519 signature for the mint step |
+| `STELLAR_NETWORK` | No | Network name; defaults to `testnet` |
+| `SKIP_MINT` | No | Set to `1` to skip the mint + query steps |
+| `KEEP_CONTRACT` | No | Set to `1` to leave the contract on testnet after the run |
+
+### Cleanup note
+
+Soroban does not support on-chain contract deletion. Deployed testnet contracts
+expire naturally via ledger TTL. Set `KEEP_CONTRACT=1` if you want to reuse the
+same contract for follow-up tests.

--- a/SECURITY_RECOMMENDATIONS.md
+++ b/SECURITY_RECOMMENDATIONS.md
@@ -1,156 +1,137 @@
 # Security Recommendations for Stellar Wrap Contract
 
 ## Overview
-This document outlines critical security enhancements needed before mainnet deployment.
+This document describes the security properties of the deployed contract, identifies
+remaining pre-mainnet work, and provides guidance for auditors.
 
-For developer-facing error handling (e.g. `Error(Contract, #4)`), see the [Error Reference (ERRORS.md)](./ERRORS.md).
-
-
+For developer-facing error handling (e.g. `Error(Contract, #4)`), see the
+[Error Reference (ERRORS.md)](./ERRORS.md).
 
 ---
 
-## 🔴 CRITICAL: Signature Verification Enhancement
+## ✅ Signature Verification — Implemented (Ed25519)
 
 ### Current State
-The `verify_signature()` function in `lib.rs` currently returns `true` unconditionally:
+`mint_wrap()` and `update_wrap()` perform real Ed25519 cryptographic signature
+verification using Soroban's built-in `e.crypto().ed25519_verify()`. The old
+unconditional stub (`fn verify_signature() -> bool { true }`) no longer exists.
 
-```rust
-fn verify_signature(_data_hash: &BytesN<32>) -> bool {
-    true  // ⚠️ INSECURE - Always passes
-}
+### How It Works
+
+The backend generates a **canonical payload** and signs it with the admin Ed25519
+private key. The contract reconstructs the same payload and verifies the signature
+against the stored admin public key before minting.
+
+#### Payload construction (`mint_wrap`)
+
+```
+payload = XDR(contract_address)
+        ‖ XDR(user)
+        ‖ XDR(period)        // u64 — prevents period replay
+        ‖ XDR(archetype)
+        ‖ XDR(data_hash)     // SHA-256 of off-chain JSON
 ```
 
-### Required Implementation
+Each field is XDR-encoded before concatenation, which provides unambiguous
+length-delimited framing and prevents field-boundary collisions.
 
-The signature must cryptographically bind:
-1. **User Address** (prevents identity theft)
-2. **Contract Address** (prevents cross-contract replay)
-3. **Period** (prevents time-based replay)
-4. **Data Hash** (prevents data tampering)
-5. **Nonce or Sequence** (optional, for additional replay protection)
-
-### Recommended Approach
-
-#### Option 1: Ed25519 Signature Verification (Recommended)
+#### On-chain verification (Rust)
 
 ```rust
-use soroban_sdk::crypto::ed25519;
+let mut payload = Bytes::new(&e);
+payload.append(&e.current_contract_address().to_xdr(&e));   // cross-contract replay protection
+payload.append(&user.clone().to_xdr(&e));                   // identity binding
+payload.append(&period.to_xdr(&e));                         // period binding
+payload.append(&archetype.clone().to_xdr(&e));
+payload.append(&data_hash.clone().to_xdr(&e));
 
-fn verify_signature(
-    e: &Env,
-    admin: &Address,
-    user: &Address,
-    period: &Symbol,
-    data_hash: &BytesN<32>,
-    signature: &BytesN<64>
-) -> bool {
-    // Construct the payload that was signed
-    let mut payload = Bytes::new(e);
-
-    // Include contract address (prevents cross-contract replay)
-    payload.append(&e.current_contract_address().to_bytes());
-
-    // Include user address (prevents identity theft)
-    payload.append(&user.to_bytes());
-
-    // Include period (prevents period replay)
-    payload.append(&period.to_bytes());
-
-    // Include data hash
-    payload.append(&data_hash.to_bytes());
-
-    // Hash the payload
-    let message = e.crypto().sha256(&payload);
-
-    // Get admin's public key and verify signature
-    // Note: You'll need to store/retrieve the admin's public key
-    let admin_pubkey = get_admin_pubkey(e);
-
-    e.crypto().ed25519_verify(
-        &admin_pubkey,
-        &message,
-        signature
-    );
-
-    true
-}
+// Panics with ContractError::InvalidSignature (code 6) on failure
+e.crypto().ed25519_verify(&admin_pubkey, &payload, &signature);
 ```
 
-#### Option 2: Use Soroban's Built-in Auth (Simpler)
+`ed25519_verify` panics (traps) when verification fails — the transaction is
+rolled back and no state is written.
 
-Instead of manual signature verification, leverage Soroban's authorization framework:
+#### Off-chain signing (TypeScript example)
 
-```rust
-pub fn mint_wrap(
-    e: Env,
-    to: Address,
-    data_hash: BytesN<32>,
-    archetype: Symbol,
-    period: Symbol,
-) {
-    let admin: Address = e
-        .storage()
-        .instance()
-        .get(&DataKey::Admin)
-        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+```typescript
+import { xdr, Address } from "@stellar/stellar-sdk";
+import * as nacl from "tweetnacl";
 
-    // This already provides cryptographic verification
-    admin.require_auth();
-
-    // Rest of implementation...
+function buildMintPayload(
+  contractId: string,
+  userAddress: string,
+  period: bigint,
+  archetype: string,
+  dataHash: Uint8Array
+): Uint8Array {
+  const parts: Uint8Array[] = [
+    xdr.ScAddress.scAddressTypeContract(Buffer.from(contractId, "hex")).toXDR(),
+    Address.fromString(userAddress).toXDR(),
+    xdr.Uint64.fromBigInt(period).toXDR(),
+    xdr.ScSymbol.encode(archetype),
+    Buffer.from(dataHash),
+  ];
+  return Buffer.concat(parts);
 }
+
+const payload  = buildMintPayload(contractId, user, period, archetype, dataHash);
+const signature = nacl.sign.detached(payload, adminSecretKey);
+// Pass signature (64 bytes) as the `signature` argument to mint_wrap()
 ```
 
-**Current code already uses `admin.require_auth()` which is secure!** However, for additional security layers (like binding to specific parameters), you may want to add custom signature verification.
+### Security Properties Provided
+
+| Property | How it is enforced |
+|---|---|
+| **Identity binding** | `user` is in the payload; a signature for Alice cannot be used by Bob |
+| **Cross-contract replay** | `contract_address` is the first payload field |
+| **Period replay** | `period` is in the payload; same user cannot reuse a signature for a different period |
+| **Data integrity** | `data_hash` (SHA-256 of JSON) is in the payload and also stored on-chain |
+| **Duplicate prevention** | `WrapAlreadyExists` check after signature verification |
 
 ---
 
 ## ✅ Security Features Already Implemented
 
-### 1. Replay Attack Protection ✓
+### 1. Replay Attack Protection
 **Status:** IMPLEMENTED
 
-The contract prevents replay attacks within the same contract instance through the duplicate check:
-
 ```rust
-let wrap_key = DataKey::Wrap(to.clone(), period.clone());
-if e.storage().instance().has(&wrap_key) {
+let wrap_key = DataKey::Wrap(user.clone(), period);
+if e.storage().persistent().has(&wrap_key) {
     panic_with_error!(e, ContractError::WrapAlreadyExists);
 }
 ```
 
-**What it prevents:**
-- Same user + same period cannot be minted twice
-- Attacker cannot replay a valid transaction
+The same `(user, period)` pair can never be minted twice regardless of whether the
+caller has a valid signature.
 
 **Test coverage:**
 - `test_replay_attack_same_period_fails` ✓
 - `test_duplicate_period_fails` ✓
 
-### 2. Authorization Protection ✓
+### 2. Authorization Protection
 **Status:** IMPLEMENTED
 
-Only the admin can authorize minting:
-
 ```rust
-admin.require_auth();
+user.require_auth();       // user must sign the Stellar transaction
+// … then …
+e.crypto().ed25519_verify(&admin_pubkey, &payload, &signature);  // admin must pre-sign payload
 ```
 
-**What it prevents:**
-- Unauthorized users cannot mint wraps
-- Only admin-signed transactions succeed
+Both conditions must hold. An attacker who controls the Stellar keypair of a user
+still cannot forge the Ed25519 admin signature, and vice-versa.
 
 **Test coverage:**
 - `test_mint_wrap_unauthorized` ✓
 - `test_non_admin_cannot_mint` ✓
 
-### 3. Initialization Protection ✓
+### 3. Initialization Protection
 **Status:** IMPLEMENTED
 
-Contract can only be initialized once:
-
 ```rust
-if e.storage().instance().has(&key) {
+if e.storage().instance().has(&DataKey::Admin) {
     panic_with_error!(e, ContractError::AlreadyInitialized);
 }
 ```
@@ -158,68 +139,124 @@ if e.storage().instance().has(&key) {
 **Test coverage:**
 - `test_initialize_twice_fails` ✓
 
----
+### 4. Reentrancy Guard
+**Status:** IMPLEMENTED
 
-## ⚠️ Security Considerations for Deployment
+A temporary-storage guard (`DataKey::MintGuard`) is set at the start of `mint_wrap`
+and removed on success. If execution panics mid-flight, Soroban's ledger rollback
+prevents the guard from persisting incorrectly.
 
-### 1. Cross-Contract Replay Protection
-**Status:** NEEDS ENHANCEMENT
-
-**Current behavior:**
-- Each contract instance has independent storage
-- A signature valid for Contract V1 could theoretically work on Contract V2
-
-**Recommendation:**
-If you plan to deploy multiple versions, include `env.current_contract_address()` in the signature payload.
+### 5. Zero-Hash Rejection
+**Status:** IMPLEMENTED
 
 ```rust
-// In signature verification
-let contract_id = e.current_contract_address();
-payload.append(&contract_id.to_bytes());
+if data_hash == BytesN::from_array(&e, &ZERO_HASH_BYTES) {
+    panic_with_error!(e, ContractError::InvalidDataHash);
+}
 ```
 
-**Test coverage:**
-- `test_cross_contract_replay_protection` ✓ (documents current behavior)
+All-zero `data_hash` values are rejected to guard against missing or
+uninitialized data.
 
-### 2. Timestamp Integrity
-**Status:** SECURE ✓
+### 6. Timestamp Integrity
+**Status:** SECURE
 
-The contract correctly uses `env.ledger().timestamp()` rather than accepting user-provided timestamps.
+The contract uses `e.ledger().timestamp()` rather than accepting a
+user-supplied timestamp. Ledger timestamps are set by consensus and cannot be
+forged by a transaction submitter.
 
 **Test coverage:**
 - `test_timestamp_is_from_ledger_not_user` ✓
 
-### 3. Identity Binding
-**Status:** SECURE (via admin auth) ✓
+### 7. Archetype Allowlist
+**Status:** IMPLEMENTED
 
-The current `admin.require_auth()` ensures only authorized transactions succeed. The `to` parameter is part of the storage key, preventing one user from claiming another's wrap.
+Archetypes are validated against an admin-managed allowlist stored in instance
+storage. Unknown archetypes are rejected with `InvalidArchetype`.
+
+```rust
+Self::validate_archetype(&e, &archetype);
+```
+
+### 8. Cross-Contract Replay Protection
+**Status:** IMPLEMENTED
+
+`e.current_contract_address()` is the first field in every signed payload. A
+signature issued for Contract V1 will fail verification on Contract V2 (different
+address) even if all other fields are identical.
 
 **Test coverage:**
-- `test_signature_cannot_be_stolen_by_another_user` ✓
+- `test_cross_contract_replay_protection` ✓
 
 ---
 
-## 📊 Gas/Resource Analysis Results
+## ⚠️ Remaining Pre-Mainnet Items
 
-Run the tests to get exact numbers:
+### 1. Signature Expiry / `expiry_ledger`
+**Status:** PARTIALLY IMPLEMENTED
+
+`mint_wrap` accepts an `expiry_ledger: u32` parameter and `sign_payload` includes
+it in the payload in tests. The on-chain check that rejects signatures past their
+expiry ledger should be confirmed present and tested end-to-end before mainnet.
+
+**Recommendation:** Verify that `mint_wrap` explicitly compares
+`e.ledger().sequence() > expiry_ledger` and panics with an appropriate error.
+Add a test that a signature with a past `expiry_ledger` is rejected.
+
+### 2. Admin Key Management
+**Status:** OPERATIONAL CONCERN
+
+The `admin_pubkey` is stored in instance storage and verified on every mint. The
+corresponding private key must be held securely (HSM or similar). Key rotation
+requires `update_admin()` followed by redeployment of a new signing service.
+
+**Recommendation:** Document the key rotation procedure and rehearse it before
+mainnet.
+
+### 3. Third-Party Security Audit
+**Status:** PENDING
+
+**Recommendation:** Engage an independent Soroban auditor before handling real
+user data at scale.
+
+### 4. Fuzz Testing
+**Status:** PENDING
+
+Consider adding property-based or fuzz tests:
+- No user should have duplicate periods.
+- Sum of all `WrapCount` values should equal `TotalMints`.
+- Any random 64-byte blob passed as `signature` must be rejected.
 
 ```bash
+cargo install cargo-fuzz
+cargo fuzz init
+cargo fuzz run fuzz_target_1
+```
+
+### 5. Upgrade Key Control
+**Status:** OPERATIONAL CONCERN
+
+`upgrade()` requires admin authorization. If the admin keypair is compromised, an
+attacker could replace the WASM. Consider a time-lock or multi-sig admin for
+production.
+
+---
+
+## 📊 Gas / Resource Analysis
+
+```bash
+# Run gas-annotated tests
 cargo test test_gas_analysis -- --nocapture
 ```
 
-Expected output:
-```
-=== GAS ANALYSIS REPORT ===
-Operation: mint_wrap
-CPU Instructions: ~[TO BE MEASURED]
-Memory Bytes: ~[TO BE MEASURED]
-===========================
-```
+### Known cost breakdown
 
-### Optimization Recommendations:
-1. **Storage**: Instance storage is used correctly (ephemeral, cheaper than persistent)
-2. **Event emission**: Minimal data in events (only period as u64)
-3. **Signature verification**: If implementing custom crypto, measure impact
+| Operation | Notable costs |
+|---|---|
+| `mint_wrap` | 2 persistent writes (`WrapRecord` + `WrapCount`), 1 temp write/remove (guard), 1 event |
+| `has_wrap` | 1 persistent `has()` call — no deserialization, cheaper than `get_wrap` |
+| `get_wrap` | 1 persistent read + XDR deserialization of `WrapRecord` |
+| `balance_of` | 1 persistent read (`WrapCount`) |
 
 ---
 
@@ -260,45 +297,39 @@ cargo test -- --nocapture --test-threads=1
 
 ## 🚀 Pre-Mainnet Checklist
 
-- [x] Replay attack protection implemented
-- [x] Authorization verification implemented
+- [x] Ed25519 signature verification implemented (`e.crypto().ed25519_verify`)
+- [x] Replay attack protection implemented (`WrapAlreadyExists` check)
+- [x] Admin authorization implemented (`require_auth`)
 - [x] Duplicate period prevention implemented
-- [x] Timestamp integrity verified
-- [x] Comprehensive test suite created
-- [ ] **CRITICAL**: Decide on signature verification approach (current admin.require_auth() may be sufficient)
-- [ ] **CRITICAL**: If deploying multiple versions, add contract address binding
-- [ ] Run gas analysis and document costs
-- [ ] Security audit by third party
+- [x] Timestamp integrity — uses ledger timestamp, not user-supplied
+- [x] Reentrancy guard (temporary storage `MintGuard`)
+- [x] Zero data_hash rejection (`InvalidDataHash`)
+- [x] Cross-contract replay protection (contract address in payload)
+- [x] Archetype allowlist validation
+- [x] Comprehensive unit + security test suite
+- [ ] Confirm `expiry_ledger` check is enforced on-chain and tested
+- [ ] Rehearse admin key rotation procedure
+- [ ] Run gas analysis and document costs for each entry point
+- [ ] Third-party security audit
 - [ ] Fuzz testing with property-based tests
-- [ ] Load testing for high-volume scenarios
+- [ ] Load/stress testing for high-volume scenarios
 
 ---
 
 ## 📚 Additional Security Best Practices
 
-### 1. Invariant Testing
-Consider adding property-based tests:
-- No user should ever have duplicate periods
-- Total wraps minted should equal sum of all user wraps
-- Timestamps should be monotonic within a session
+### Invariant Testing
 
-### 2. Fuzz Testing
-Use `cargo-fuzz` to test with random inputs:
-```bash
-cargo install cargo-fuzz
-cargo fuzz init
-cargo fuzz run fuzz_target_1
-```
+Consider property-based tests verifying:
+- No user ever has duplicate periods.
+- Total wraps minted equals sum of all user `WrapCount` values.
+- Timestamps are monotonic within a session.
 
-### 3. Access Control Review
-- Ensure `initialize()` is called during deployment
-- Verify admin key is secured in production
-- Consider multi-sig admin for production
+### Access Control Review
 
-### 4. Upgrade Strategy
-- Plan for contract upgrades if needed
-- Consider using a proxy pattern
-- Document migration procedures
+- Confirm `initialize()` is called exactly once during deployment.
+- Verify admin key is stored securely (HSM or equivalent) in production.
+- Consider multi-sig admin (`require_auth_for_args`) for production upgrade control.
 
 ---
 
@@ -307,15 +338,4 @@ cargo fuzz run fuzz_target_1
 - [Soroban Security Best Practices](https://soroban.stellar.org/docs/learn/security)
 - [Stellar Smart Contract Audit Guidelines](https://stellar.org/developers)
 - [Soroban Auth Framework](https://soroban.stellar.org/docs/learn/authorization)
-
----
-
-## 📧 Questions?
-
-If implementing custom signature verification, consider:
-1. Key management strategy
-2. Signature format and standards
-3. Off-chain signature generation process
-4. Recovery mechanisms
-
-**Current Assessment:** The contract uses Soroban's built-in `require_auth()` which is cryptographically secure and prevents most attack vectors. Additional custom signature verification is optional and depends on your specific security requirements.
+- [Soroban `ed25519_verify` docs](https://docs.rs/soroban-sdk/latest/soroban_sdk/crypto/struct.Crypto.html)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -668,6 +668,27 @@ impl StellarWrapContract {
         }
     }
 
+    /// Lightweight existence check — returns `true` if a wrap record exists for
+    /// `(user, period)`, `false` otherwise.
+    ///
+    /// This is cheaper than `get_wrap()` for callers that only need to know whether
+    /// a wrap exists, because it performs a single persistent-storage `has()` probe
+    /// without deserializing the full `WrapRecord`.
+    ///
+    /// # Parameters
+    /// - `user`: The address to check.
+    /// - `period`: The period identifier to look up.
+    ///
+    /// # Returns
+    /// `true` if a `WrapRecord` is stored for `(user, period)`, `false` otherwise.
+    /// Note: this returns `true` even when the user has opted out of visibility —
+    /// use `get_wrap()` when you need to respect opt-out status.
+    pub fn has_wrap(e: Env, user: Address, period: u64) -> bool {
+        e.storage()
+            .persistent()
+            .has(&DataKey::Wrap(user, period))
+    }
+
             }
             None => false,
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1845,3 +1845,172 @@ fn test_update_wrap_zero_hash_rejected() {
     env.mock_all_auths();
     register_test_archetypes(&client);
 
+
+// ─── Issue #53: has_wrap() tests ────────────────────────────────────────────
+
+/// has_wrap() returns false before any wrap is minted for a user+period pair.
+#[test]
+fn test_has_wrap_returns_false_before_mint() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[60u8; 32]);
+    client.initialize(&admin, &pubkey);
+
+    let user = Address::generate(&env);
+    let period = 202406u64;
+
+    assert!(!client.has_wrap(&user, &period));
+}
+
+/// has_wrap() returns true after a successful mint for the same user+period.
+#[test]
+fn test_has_wrap_returns_true_after_mint() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[61u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+    register_test_archetypes(&client);
+
+    let period = 202406u64;
+    let archetype = symbol_short!("arch");
+    let data_hash = BytesN::from_array(&env, &[61u8; 32]);
+    let signature = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &data_hash,
+        u32::MAX,
+    );
+
+    // Before mint: should not exist.
+    assert!(!client.has_wrap(&user, &period));
+
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+
+    // After mint: must exist.
+    assert!(client.has_wrap(&user, &period));
+}
+
+/// has_wrap() is period-scoped: true for minted period, false for different period.
+#[test]
+fn test_has_wrap_is_scoped_to_period() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[62u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+    register_test_archetypes(&client);
+
+    let period_a = 202406u64;
+    let period_b = 202407u64;
+    let archetype = symbol_short!("arch");
+    let data_hash = BytesN::from_array(&env, &[62u8; 32]);
+    let signature = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period_a,
+        &archetype,
+        &data_hash,
+        u32::MAX,
+    );
+
+    client.mint_wrap(&user, &period_a, &archetype, &data_hash, &signature);
+
+    assert!(client.has_wrap(&user, &period_a));
+    assert!(!client.has_wrap(&user, &period_b));
+}
+
+/// has_wrap() returns false after the wrap is revoked.
+#[test]
+fn test_has_wrap_returns_false_after_revoke() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[63u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+    register_test_archetypes(&client);
+
+    let period = 202406u64;
+    let archetype = symbol_short!("arch");
+    let data_hash = BytesN::from_array(&env, &[63u8; 32]);
+    let signature = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &data_hash,
+        u32::MAX,
+    );
+
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+    assert!(client.has_wrap(&user, &period));
+
+    client.revoke_wrap(&user, &period);
+    assert!(!client.has_wrap(&user, &period));
+}
+
+/// has_wrap() is user-scoped: true for user A, false for user B on same period.
+#[test]
+fn test_has_wrap_is_scoped_to_user() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[64u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+    register_test_archetypes(&client);
+
+    let period = 202406u64;
+    let archetype = symbol_short!("arch");
+    let data_hash = BytesN::from_array(&env, &[64u8; 32]);
+    let signature = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user_a,
+        period,
+        &archetype,
+        &data_hash,
+        u32::MAX,
+    );
+
+    client.mint_wrap(&user_a, &period, &archetype, &data_hash, &signature);
+
+    assert!(client.has_wrap(&user_a, &period));
+    assert!(!client.has_wrap(&user_b, &period));
+}

--- a/tests/integration_testnet.sh
+++ b/tests/integration_testnet.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# tests/integration_testnet.sh
+#
+# End-to-end integration test for stellar-wrap-contract on Stellar testnet.
+#
+# Prerequisites
+# ─────────────
+#   • stellar CLI installed (https://developers.stellar.org/docs/tools/stellar-cli)
+#   • Rust + cargo installed with wasm32-unknown-unknown target
+#   • A funded Stellar testnet keypair (use `stellar keys generate --network testnet`)
+#
+# Required environment variables
+# ────────────────────────────────
+#   STELLAR_DEPLOYER_SECRET  – Secret key for a funded testnet account used to
+#                              deploy the contract and call admin functions.
+#   STELLAR_ADMIN_PUBKEY     – 32-byte hex Ed25519 public key passed to initialize().
+#                              The matching private key must be available to sign
+#                              mint payloads (see sign_payload() below).
+#
+# Optional environment variables
+# ────────────────────────────────
+#   STELLAR_NETWORK          – Defaults to "testnet"
+#   KEEP_CONTRACT            – Set to "1" to skip contract cleanup at the end.
+#
+# Usage
+# ─────
+#   export STELLAR_DEPLOYER_SECRET=SXXXXXXX...
+#   export STELLAR_ADMIN_PUBKEY=aabbcc...   # 64 hex chars (32 bytes)
+#   bash tests/integration_testnet.sh
+#
+# Note: This script is NOT run in CI by default. It is intended for manual
+# pre-deployment smoke testing against a live Stellar testnet node.
+#
+# What it tests
+# ─────────────
+#   1. Build WASM from source
+#   2. Deploy contract to testnet
+#   3. Call initialize() with admin address and pubkey
+#   4. Mint a wrap record
+#   5. Call get_wrap() and verify the returned record
+#   6. Call has_wrap() and verify it returns true
+#   7. Call balance_of() and verify count is 1
+#   8. (Optional cleanup) Remove the test contract
+
+set -euo pipefail
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+NETWORK="${STELLAR_NETWORK:-testnet}"
+WASM_PATH="target/wasm32-unknown-unknown/release/stellar_wrap_contract.wasm"
+CONTRACT_ID_FILE="tests/.testnet_contract_id"
+
+# Validate required env vars
+if [[ -z "${STELLAR_DEPLOYER_SECRET:-}" ]]; then
+  echo "ERROR: STELLAR_DEPLOYER_SECRET is not set." >&2
+  echo "  export STELLAR_DEPLOYER_SECRET=SXXXXXXX..." >&2
+  exit 1
+fi
+
+if [[ -z "${STELLAR_ADMIN_PUBKEY:-}" ]]; then
+  echo "ERROR: STELLAR_ADMIN_PUBKEY is not set." >&2
+  echo "  export STELLAR_ADMIN_PUBKEY=<64-hex-char Ed25519 pubkey>" >&2
+  exit 1
+fi
+
+# Derive the deployer's public address from the secret key
+DEPLOYER_ADDRESS=$(stellar keys address --secret-key "${STELLAR_DEPLOYER_SECRET}" 2>/dev/null || \
+  stellar keys address "deployer" 2>/dev/null || \
+  echo "UNKNOWN")
+
+echo "============================================================"
+echo " Stellar Wrap Contract — Testnet Integration Test"
+echo "============================================================"
+echo "  Network  : ${NETWORK}"
+echo "  Deployer : ${DEPLOYER_ADDRESS}"
+echo "  WASM     : ${WASM_PATH}"
+echo ""
+
+# ── Step 1: Build ─────────────────────────────────────────────────────────────
+
+echo "[ 1/8 ] Building WASM…"
+cargo build --release --target wasm32-unknown-unknown --quiet
+echo "        ✓ ${WASM_PATH} built"
+
+# ── Step 2: Deploy ────────────────────────────────────────────────────────────
+
+echo "[ 2/8 ] Deploying contract to ${NETWORK}…"
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "${WASM_PATH}" \
+  --network "${NETWORK}" \
+  --source "${STELLAR_DEPLOYER_SECRET}")
+
+echo "        ✓ Contract deployed: ${CONTRACT_ID}"
+echo "${CONTRACT_ID}" > "${CONTRACT_ID_FILE}"
+
+# ── Step 3: Initialize ────────────────────────────────────────────────────────
+
+echo "[ 3/8 ] Initializing contract…"
+stellar contract invoke \
+  --id "${CONTRACT_ID}" \
+  --network "${NETWORK}" \
+  --source "${STELLAR_DEPLOYER_SECRET}" \
+  -- initialize \
+  --admin "${DEPLOYER_ADDRESS}" \
+  --admin_pubkey "${STELLAR_ADMIN_PUBKEY}"
+echo "        ✓ Initialized (admin=${DEPLOYER_ADDRESS})"
+
+# ── Step 4: Seed test data ────────────────────────────────────────────────────
+#
+# In a full integration test, the backend would generate a real Ed25519
+# signature over the canonical payload. Here we call add_archetype and
+# demonstrate that the CLI invocation pattern is correct.
+# Minting requires a valid 64-byte signature from the admin private key —
+# see the TypeScript signing example in SECURITY_RECOMMENDATIONS.md.
+#
+# The snippet below shows the CLI shape; replace <SIGNATURE_HEX> with a
+# real signature produced by your signing service.
+
+TEST_USER="${DEPLOYER_ADDRESS}"
+TEST_PERIOD="202406"
+TEST_ARCHETYPE="builder"
+TEST_DATA_HASH="0101010101010101010101010101010101010101010101010101010101010101"
+
+echo "[ 4/8 ] Registering test archetype '${TEST_ARCHETYPE}'…"
+stellar contract invoke \
+  --id "${CONTRACT_ID}" \
+  --network "${NETWORK}" \
+  --source "${STELLAR_DEPLOYER_SECRET}" \
+  -- add_archetype \
+  --archetype "${TEST_ARCHETYPE}"
+echo "        ✓ Archetype registered"
+
+echo "[ 4/8 ] Minting wrap (requires valid Ed25519 signature)…"
+echo "        NOTE: Set SKIP_MINT=1 to skip the mint step if you do not have"
+echo "              an admin signing service available."
+if [[ "${SKIP_MINT:-0}" == "1" ]]; then
+  echo "        ⚠ Skipping mint (SKIP_MINT=1)"
+else
+  # Replace <SIGNATURE_HEX> with a real 64-byte Ed25519 signature
+  # produced by signing: XDR(contract_id) ‖ XDR(user) ‖ XDR(period) ‖
+  #                      XDR(archetype) ‖ XDR(data_hash)
+  SIGNATURE_HEX="${STELLAR_MINT_SIGNATURE:-}"
+  if [[ -z "${SIGNATURE_HEX}" ]]; then
+    echo "        ⚠ STELLAR_MINT_SIGNATURE not set — skipping mint verification step."
+    echo "          Set STELLAR_MINT_SIGNATURE=<128-hex-char Ed25519 signature> to test minting."
+  else
+    stellar contract invoke \
+      --id "${CONTRACT_ID}" \
+      --network "${NETWORK}" \
+      --source "${STELLAR_DEPLOYER_SECRET}" \
+      -- mint_wrap \
+      --user "${TEST_USER}" \
+      --period "${TEST_PERIOD}" \
+      --archetype "${TEST_ARCHETYPE}" \
+      --data_hash "${TEST_DATA_HASH}" \
+      --signature "${SIGNATURE_HEX}"
+    echo "        ✓ Wrap minted"
+
+    # ── Step 5: get_wrap ────────────────────────────────────────────────────
+    echo "[ 5/8 ] Querying get_wrap(${TEST_USER}, ${TEST_PERIOD})…"
+    GET_RESULT=$(stellar contract invoke \
+      --id "${CONTRACT_ID}" \
+      --network "${NETWORK}" \
+      --source "${STELLAR_DEPLOYER_SECRET}" \
+      -- get_wrap \
+      --user "${TEST_USER}" \
+      --period "${TEST_PERIOD}")
+    echo "        ✓ get_wrap result: ${GET_RESULT}"
+
+    # ── Step 6: has_wrap ────────────────────────────────────────────────────
+    echo "[ 6/8 ] Querying has_wrap(${TEST_USER}, ${TEST_PERIOD})…"
+    HAS_RESULT=$(stellar contract invoke \
+      --id "${CONTRACT_ID}" \
+      --network "${NETWORK}" \
+      --source "${STELLAR_DEPLOYER_SECRET}" \
+      -- has_wrap \
+      --user "${TEST_USER}" \
+      --period "${TEST_PERIOD}")
+    if [[ "${HAS_RESULT}" != "true" ]]; then
+      echo "        ✗ FAIL: has_wrap returned '${HAS_RESULT}', expected 'true'" >&2
+      exit 1
+    fi
+    echo "        ✓ has_wrap = true"
+
+    # ── Step 7: balance_of ──────────────────────────────────────────────────
+    echo "[ 7/8 ] Querying balance_of(${TEST_USER})…"
+    BALANCE=$(stellar contract invoke \
+      --id "${CONTRACT_ID}" \
+      --network "${NETWORK}" \
+      --source "${STELLAR_DEPLOYER_SECRET}" \
+      -- balance_of \
+      --id "${TEST_USER}")
+    if [[ "${BALANCE}" != "1" ]]; then
+      echo "        ✗ FAIL: balance_of returned '${BALANCE}', expected '1'" >&2
+      exit 1
+    fi
+    echo "        ✓ balance_of = 1"
+  fi
+fi
+
+# ── Step 8: Cleanup ───────────────────────────────────────────────────────────
+
+echo "[ 8/8 ] Cleanup…"
+if [[ "${KEEP_CONTRACT:-0}" == "1" ]]; then
+  echo "        ⚠ KEEP_CONTRACT=1 — contract ${CONTRACT_ID} left on testnet."
+  echo "          To clean up manually: rm ${CONTRACT_ID_FILE}"
+else
+  # Soroban does not support deleting contracts, but we can clean up the
+  # local reference file.
+  if [[ -f "${CONTRACT_ID_FILE}" ]]; then
+    rm "${CONTRACT_ID_FILE}"
+  fi
+  echo "        ✓ Local contract-id file removed."
+  echo "        ℹ  Note: Soroban/Stellar does not support on-chain contract deletion."
+  echo "           The contract remains on testnet but will expire via ledger TTL."
+fi
+
+echo ""
+echo "============================================================"
+echo " Integration test complete ✓"
+echo "  Contract ID : ${CONTRACT_ID}"
+echo "============================================================"


### PR DESCRIPTION
…urity docs

Closes #50, #51, #53, #54

## #50 — Fix stale stub in SECURITY_RECOMMENDATIONS.md
- Remove references to the unconditional verify_signature() stub
- Document the real Ed25519 verification flow: canonical payload construction (XDR-encoded contract_id ‖ user ‖ period ‖ archetype ‖ data_hash), ed25519_verify() call, and off-chain TypeScript signing example
- Add security-property table (identity binding, cross-contract replay, period replay, data integrity, duplicate prevention)
- Update pre-mainnet checklist: mark 9 items done, list 5 remaining (expiry_ledger enforcement, key rotation, audit, fuzz, upgrade key control)

## #53 — Add has_wrap() lightweight existence check
- Add pub fn has_wrap(e, user, period) -> bool using a single persistent storage has() probe — no WrapRecord deserialization
- Cheaper than get_wrap() for callers that only need existence
- Note in doc comment: respects storage key but not opt-out status
- Add 5 unit tests in src/test.rs: test_has_wrap_returns_false_before_mint test_has_wrap_returns_true_after_mint test_has_wrap_is_scoped_to_period test_has_wrap_returns_false_after_revoke test_has_wrap_is_scoped_to_user

## #54 — Expand Makefile with missing dev-workflow targets
- build / wasm-build: cargo build --release --target wasm32-unknown-unknown
- test / test-verbose: cargo test (with optional --nocapture)
- fmt / fmt-check: rustfmt auto-format and CI-safe check mode
- lint: cargo clippy -- -D warnings
- deploy-testnet: stellar contract deploy; supports CONTRACT_ID= for upgrades
- clean: cargo clean
- docker-build / docker-build-verify: reproducible WASM builds
- help: self-documenting target list

## #51 — Add testnet integration test script
- Create tests/integration_testnet.sh (not run in CI by default)
- Steps: build WASM, deploy, initialize, add_archetype, mint_wrap (when STELLAR_MINT_SIGNATURE is set), verify get_wrap / has_wrap / balance_of, cleanup local contract-id file
- Supports SKIP_MINT=1 and KEEP_CONTRACT=1 escape hatches
- Add README section: prerequisites, usage, step table, env-var reference
- 
Closes #50 
Closes #51 
Closes #53 
Closes #54 