### PR TITLE
test: add token metadata constants and upgrade stability regression test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,14 +10,15 @@ mod storage_types;
 use merkle::{compute_merkle_leaf, verify_merkle_proof};
 use storage_types::{
     ContractInfo, DataKey, WrapRecord, WrapRecordV1, SCHEMA_VERSION, SCHEMA_VERSION_V2,
+    TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS, CONTRACT_DESCRIPTION,
 };
 
 soroban_sdk::contractmeta!(
     key = "Description",
-    val = "Soulbound token registry for Stellar Wrap"
+    val = CONTRACT_DESCRIPTION
 );
 soroban_sdk::contractmeta!(key = "Version", val = "0.1.0");
-soroban_sdk::contractmeta!(key = "Name", val = "Stellar Wrap Registry");
+soroban_sdk::contractmeta!(key = "Name", val = TOKEN_NAME);
 soroban_sdk::contractmeta!(key = "Author", val = "Stellar Wrap Team");
 
 /// Errors returned by the StellarWrap contract.
@@ -880,7 +881,7 @@ impl StellarWrapContract {
     /// # Returns
     /// `"Stellar Wrap Registry"`
     pub fn name(e: Env) -> String {
-        String::from_str(&e, "Stellar Wrap Registry")
+        String::from_str(&e, TOKEN_NAME)
     }
 
     /// Return the ticker symbol for this token registry.
@@ -888,21 +889,21 @@ impl StellarWrapContract {
     /// # Returns
     /// `"WRAP"`
     pub fn symbol(e: Env) -> String {
-        String::from_str(&e, "WRAP")
+        String::from_str(&e, TOKEN_SYMBOL)
     }
 
     /// Return the number of decimals. Soulbound tokens are non-divisible, so this is always `0`.
     pub fn decimals(_e: Env) -> u32 {
-        0
+        TOKEN_DECIMALS
     }
 
     /// Return contract-level metadata useful for explorers and indexers.
     pub fn contract_info(e: Env) -> ContractInfo {
         ContractInfo {
-            name: String::from_str(&e, "Stellar Wrap Registry"),
+            name: String::from_str(&e, TOKEN_NAME),
             version: String::from_str(&e, "0.1.0"),
             repo: String::from_str(&e, "https://github.com/zintarh/stellar-wrap-contract"),
-            description: String::from_str(&e, "Soulbound token registry for Stellar Wrap"),
+            description: String::from_str(&e, CONTRACT_DESCRIPTION),
         }
     }
 

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -1,5 +1,16 @@
 use soroban_sdk::{contracttype, Address, BytesN, String, Symbol};
 
+/// Token metadata constants.
+///
+/// WARNING: Changing these values is a BREAKING CHANGE for indexers and
+/// downstream consumers that rely on stable token identifiers. The `name()`,
+/// `symbol()`, and `decimals()` functions must remain stable across contract
+/// upgrades to preserve indexer compatibility.
+pub const TOKEN_NAME: &str = "Stellar Wrap Registry";
+pub const TOKEN_SYMBOL: &str = "WRAP";
+pub const TOKEN_DECIMALS: u32 = 0;
+pub const CONTRACT_DESCRIPTION: &str = "Soulbound token registry for Stellar Wrap";
+
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ContractInfo {

--- a/src/test.rs
+++ b/src/test.rs
@@ -11,7 +11,7 @@ use soroban_sdk::{
 };
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
-use crate::storage_types::{DataKey, WrapRecord};
+use crate::storage_types::{DataKey, WrapRecord, TOKEN_NAME, TOKEN_SYMBOL, TOKEN_DECIMALS, CONTRACT_DESCRIPTION};
 
 fn sign_payload(
     env: &Env,
@@ -341,12 +341,45 @@ fn test_token_metadata() {
     let contract_id = env.register_contract(None, StellarWrapContract);
     let client = StellarWrapContractClient::new(&env, &contract_id);
 
-    assert_eq!(client.decimals(), 0);
-    assert_eq!(
-        client.name(),
-        String::from_str(&env, "Stellar Wrap Registry")
-    );
-    assert_eq!(client.symbol(), String::from_str(&env, "WRAP"));
+    // Verify all three metadata functions match expected constants
+    assert_eq!(client.decimals(), TOKEN_DECIMALS);
+    assert_eq!(client.name(), String::from_str(&env, TOKEN_NAME));
+    assert_eq!(client.symbol(), String::from_str(&env, TOKEN_SYMBOL));
+}
+
+/// Regression test: Verify `name()`, `symbol()`, and `decimals()` return stable
+/// values across contract upgrades. These functions are pure view functions that
+/// must not change after a WASM upgrade to maintain indexer compatibility.
+///
+/// NOTE: These functions return constant values hardcoded in the contract.
+/// Changing TOKEN_NAME, TOKEN_SYMBOL, or TOKEN_DECIMALS is a BREAKING CHANGE
+/// for indexers and downstream consumers that cache these values.
+#[test]
+fn test_token_metadata_preserved_after_upgrade() {
+    let env = Env::default();
+
+    // Deploy V1 of the contract and verify metadata
+    let contract_v1_id = env.register_contract(None, StellarWrapContract);
+    let client_v1 = StellarWrapContractClient::new(&env, &contract_v1_id);
+
+    assert_eq!(client_v1.decimals(), TOKEN_DECIMALS, "V1 decimals");
+    assert_eq!(client_v1.name(), String::from_str(&env, TOKEN_NAME), "V1 name");
+    assert_eq!(client_v1.symbol(), String::from_str(&env, TOKEN_SYMBOL), "V1 symbol");
+
+    // Deploy V2 (simulated upgrade) - metadata must be identical
+    // In a real upgrade, the same contract address would run new WASM code,
+    // but in test we simulate by deploying a fresh instance with the same code.
+    let contract_v2_id = env.register_contract(None, StellarWrapContract);
+    let client_v2 = StellarWrapContractClient::new(&env, &contract_v2_id);
+
+    assert_eq!(client_v2.decimals(), TOKEN_DECIMALS, "V2 decimals must match V1");
+    assert_eq!(client_v2.name(), String::from_str(&env, TOKEN_NAME), "V2 name must match V1");
+    assert_eq!(client_v2.symbol(), String::from_str(&env, TOKEN_SYMBOL), "V2 symbol must match V1");
+
+    // Verify both contract instances return identical metadata
+    assert_eq!(client_v1.decimals(), client_v2.decimals(), "decimals stable across versions");
+    assert_eq!(client_v1.name(), client_v2.name(), "name stable across versions");
+    assert_eq!(client_v1.symbol(), client_v2.symbol(), "symbol stable across versions");
 }
 
 // ─── Issue #56: contract_info tests ─────────────────────────────────────────
@@ -358,16 +391,13 @@ fn test_contract_info_returns_correct_fields() {
     let client = StellarWrapContractClient::new(&env, &contract_id);
 
     let info = client.contract_info();
-    assert_eq!(info.name, String::from_str(&env, "Stellar Wrap Registry"));
+    assert_eq!(info.name, String::from_str(&env, TOKEN_NAME));
     assert_eq!(info.version, String::from_str(&env, "0.1.0"));
     assert_eq!(
         info.repo,
         String::from_str(&env, "https://github.com/zintarh/stellar-wrap-contract")
     );
-    assert_eq!(
-        info.description,
-        String::from_str(&env, "Soulbound token registry for Stellar Wrap")
-    );
+    assert_eq!(info.description, String::from_str(&env, CONTRACT_DESCRIPTION));
 }
 
 // ─── Issue #84: extend_ttl tests ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements Issue #58: Add test for name(), symbol(), decimals() return values stability across contract upgrades.

## Changes Made

### 1. Added Token Metadata Constants (storage_types.rs)
- `TOKEN_NAME = "Stellar Wrap Registry"`
- `TOKEN_SYMBOL = "WRAP"`
- `TOKEN_DECIMALS = 0`
- `CONTRACT_DESCRIPTION = "Soulbound token registry for Stellar Wrap"`

Each constant includes documentation warning that changing these values is a **BREAKING CHANGE** for indexers and downstream consumers that rely on stable token identifiers.

### 2. Updated Contract Functions (lib.rs)
- `name()` now uses `TOKEN_NAME` constant
- `symbol()` now uses `TOKEN_SYMBOL` constant
- `decimals()` now returns `TOKEN_DECIMALS` constant
- `contract_info()` uses the constants for name and description fields
- Contract metadata uses `TOKEN_NAME` and `CONTRACT_DESCRIPTION`

### 3. Added Regression Test (test.rs)
- `test_token_metadata_preserved_after_upgrade()` - verifies that metadata values remain stable across contract upgrades by deploying two contract instances and comparing their metadata
- Updated `test_token_metadata()` and `test_contract_info_returns_correct_fields()` to use the central constants

## Acceptance Criteria
- [x] Verify test covers all three functions (name, symbol, decimals)
- [x] Add constants for expected values to make changes intentional
- [x] Document that changing these is a breaking change for indexers

Closes #58