### PR TITLE
Add reentrancy guard to mint_wrap with ReentrancyDetected error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub enum ContractError {
     InvalidSignature = 6,
     /// `data_hash` is all-zero bytes, which indicates missing or invalid data. (code 7)
     InvalidDataHash = 7,
+    /// Reentrancy was detected during a mint operation. (code 8)
+    ReentrancyDetected = 8,
 #[contract]
 pub struct StellarWrapContract;
 
@@ -156,7 +158,7 @@ impl StellarWrapContract {
         // If execution panics, the temporary TTL naturally clears stale entries.
         let guard_key = DataKey::MintGuard(user.clone());
         if e.storage().temporary().has(&guard_key) {
-            panic_with_error!(e, ContractError::Unauthorized);
+            panic_with_error!(e, ContractError::ReentrancyDetected);
         }
         e.storage().temporary().set(&guard_key, &true);
 
@@ -208,6 +210,8 @@ impl StellarWrapContract {
 
         Self::persist_wrap_record(&e, symbol_short!("default"), user.clone(), period, record, archetype);
 
+        e.storage().temporary().remove(&guard_key);
+    }
 
     pub fn mint_campaign_wrap(
         e: Env,
@@ -240,7 +244,7 @@ impl StellarWrapContract {
 
         let guard_key = DataKey::MintGuard(user.clone());
         if e.storage().temporary().has(&guard_key) {
-            panic_with_error!(e, ContractError::Unauthorized);
+            panic_with_error!(e, ContractError::ReentrancyDetected);
         }
         e.storage().temporary().set(&guard_key, &true);
 
@@ -324,7 +328,7 @@ impl StellarWrapContract {
 
         let guard_key = DataKey::MintGuard(user.clone());
         if e.storage().temporary().has(&guard_key) {
-            panic_with_error!(e, ContractError::Unauthorized);
+            panic_with_error!(e, ContractError::ReentrancyDetected);
         }
         e.storage().temporary().set(&guard_key, &true);
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1431,6 +1431,8 @@ fn test_mint_guard_uses_temporary_storage_and_clears_on_success() {
         u32::MAX,
     );
 
+    // Successful mint — guard must be set then cleared.
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
 
     let guard_key = DataKey::MintGuard(user.clone());
     env.as_contract(&contract_id, || {
@@ -1469,6 +1471,11 @@ fn test_mint_guard_on_failure_leaves_no_residual_state() {
     );
 
     // First mint succeeds.
+    client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
+
+    // Second mint with same (user, period) fails due to duplicate guard.
+    let duplicate = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
     }));
     assert!(duplicate.is_err());
 


### PR DESCRIPTION
- Add ReentrancyDetected (code 8) variant to ContractError enum
- Use ReentrancyDetected instead of Unauthorized for guard violation
- Remove guard after successful mint_wrap completion
- Use ReentrancyDetected in mint_campaign_wrap and claim_wrap
- Add test: guard is cleared after successful mint (test_mint_guard_uses_temporary_storage_and_clears_on_success)
- Fix test: guard leaves no residual state after failure (test_mint_guard_on_failure_leaves_no_residual_state)

Closes #44 