### PR TITLE
fix: pin ed25519-dalek to 2.1.1 and add cargo-audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,17 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+    - name: Run cargo audit
+      uses: rustsec/audit-check@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
   test:
     runs-on: ubuntu-latest
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ soroban-sdk = "21.7.1"
 # Main Soroban SDK with test utilities (required for Address::generate, mock_auths, etc.)
 soroban-sdk = { version = "21.7.1", features = ["testutils"] }
 
-# Used for signature generation in property tests
-ed25519-dalek = { version = "2.1", features = ["rand_core"] }
+# Used for signature generation in property tests.
+# Pinned to 2.1.1 (latest 2.1.x patch); versions < 2.0 are vulnerable to
+# RUSTSEC-2022-0093 (double public key signing oracle attack), fixed in 2.0+.
+ed25519-dalek = { version = "=2.1.1", features = ["rand_core"] }
 
 # Property-based testing
 proptest = { version = "1", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Audited dev-dependency ed25519-dalek against the RustSec advisory database: only known advisory is RUSTSEC-2022-0093 (double public key signing oracle), fixed in 2.0+ — the crate's current 2.1 requirement is unaffected. Pin to the exact latest 2.1.x patch (2.1.1) instead of a loose "2.1" range so patch upgrades are deliberate, and add a rustsec/audit-check job to CI so future advisories are caught automatically. Also checked soroban-sdk 21.7.1: no entry exists in the RustSec advisory-db, so there are no known CVEs against it.

Closes #77