### PR TITLE
Add get_mint_timestamp read method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,13 @@ impl StellarWrapContract {
         queries::get_wrap(e, user, period)
     }
 
+    /// Returns the mint timestamp for a known user-period.
+    /// The timestamp reflects ledger time, not wall-clock time.
+    /// Returns `None` if no mint has occurred for the given user-period.
+    pub fn get_mint_timestamp(e: Env, user: Address, period: u64) -> Option<u64> {
+        queries::get_mint_timestamp(e, user, period)
+    }
+
     pub fn balance_of(e: Env, user: Address) -> i128 {
         queries::balance_of(e, user)
     }

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -6,6 +6,11 @@ pub(crate) fn get_wrap(e: Env, user: Address, period: u64) -> Option<WrapRecord>
     e.storage().persistent().get(&DataKey::Wrap(user, period))
 }
 
+pub(crate) fn get_mint_timestamp(e: Env, user: Address, period: u64) -> Option<u64> {
+    let wrap: Option<WrapRecord> = e.storage().persistent().get(&DataKey::Wrap(user, period));
+    wrap.map(|r| r.timestamp)
+}
+
 pub(crate) fn balance_of(e: Env, user: Address) -> i128 {
     let count_key = DataKey::WrapCount(user);
     e.storage()

--- a/src/test.rs
+++ b/src/test.rs
@@ -662,3 +662,51 @@ fn test_get_admin_before_init_returns_none() {
 
     assert!(client.get_admin().is_none());
 }
+
+#[test]
+fn test_get_mint_timestamp_exists() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[14u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let dummy_hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 202401u64;
+
+    let signature = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &dummy_hash,
+    );
+    client.mint_wrap(&user, &period, &archetype, &dummy_hash, &signature);
+
+    let wrap = client.get_wrap(&user, &period).unwrap();
+    assert_eq!(
+        client.get_mint_timestamp(&user, &period),
+        Some(wrap.timestamp)
+    );
+}
+
+#[test]
+fn test_get_mint_timestamp_missing() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let period = 202401u64;
+
+    assert_eq!(client.get_mint_timestamp(&user, &period), None);
+}


### PR DESCRIPTION
# Fixes #281 - Add get_mint_timestamp read method

### Summary
This PR adds a read method to return the mint timestamp for a given user-period as an `Option<u64>`, resolving issue #281.

### Acceptance Criteria
- **Read Method**: Implemented `get_mint_timestamp(e: Env, user: Address, period: u64) -> Option<u64>`.
- **Tests**: Added `test_get_mint_timestamp_exists` and `test_get_mint_timestamp_missing` testing both scenarios in `src/test.rs`.
- **Documentation**: Explicitly documented that the returned timestamp represents ledger time, not wall-clock time, and returns `None` if no mint has occurred.

### Notes for Reviewers
- The baseline test suite (`cargo test`) failed to compile prior to these changes due to a dependency resolution error in `soroban-env-host` v21.2.1 (`ChaCha20Rng: ed25519_dalek::rand_core::CryptoRng` trait bound not satisfied). The changes introduced here follow existing storage patterns and should be structurally sound once the dependency tree compiles.
- Extracted the timestamp as a `u64` based on the existing `WrapRecord { timestamp: u64 }` struct implementation.
- Pre-existing clippy warnings in `src/mint.rs` regarding manual range bounds were left untouched as they were out of scope.
