### PR TITLE
docs: clarify soulbound behavior and lack of transfer functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Each wrap record stores:
 - year must be between `2024` and `2100`
 - month must be between `01` and `12`
 
+## SBT compatibility
+
+Wrap records are implemented as non-transferable (soulbound) entries. The contract intentionally omits `transfer`, `transfer_from`, `approve`, and `allowance` methods. As a result:
+
+- `balance_of(user)` returns the number of wrap records minted for `user`, not a tradable token balance.
+- records cannot be transferred between addresses by users.
+- any future removal or replacement of a wrap record would require an admin-controlled operation, not a user-initiated transfer.
+
 ## Storage keys
 
 - `DataKey::Admin`


### PR DESCRIPTION
Adds an SBT compatibility section to the README that explains:
- transfer, transfer_from, approve, and allowance methods are intentionally absent
- balance_of should be interpreted as a record count, not a tradable token balance
- any removal or replacement of a wrap record is admin-only, not a user-initiated transfer  closes #219 