### PR TITLE
feat: Add admin action audit events for upgrade

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{panic_with_error, Address, BytesN, Env};
+use soroban_sdk::{panic_with_error, symbol_short, Address, BytesN, Env};
 
 use crate::{ContractError, DataKey};
 
@@ -21,4 +21,21 @@ pub(crate) fn update_admin(e: Env, new_admin: Address) {
 
     current_admin.require_auth();
     e.storage().instance().set(&DataKey::Admin, &new_admin);
+}
+
+pub(crate) fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
+    let current_admin: Address = e
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+    current_admin.require_auth();
+
+    // Emit audit event with the requested WASM hash before performing the upgrade
+    e.events()
+        .publish((symbol_short!("upgrade"),), new_wasm_hash.clone());
+
+    // Update the contract WASM with the provided hash
+    e.deployer().update_current_contract_wasm(new_wasm_hash);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,10 @@ impl StellarWrapContract {
         admin::update_admin(e, new_admin);
     }
 
+    pub fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
+        admin::upgrade(e, new_wasm_hash);
+    }
+
     pub fn mint_wrap(
         e: Env,
         user: Address,

--- a/src/test.rs
+++ b/src/test.rs
@@ -662,3 +662,60 @@ fn test_get_admin_before_init_returns_none() {
 
     assert!(client.get_admin().is_none());
 }
+
+#[test]
+fn test_upgrade_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    let new_wasm_hash = BytesN::from_array(&env, &[42u8; 32]);
+    client.upgrade(&new_wasm_hash);
+
+    let events = env.events().all();
+    let last_event = events.last().expect("no events found");
+    let (_, topics, data) = last_event;
+
+    let event_topic: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let event_wasm_hash: BytesN<32> = data.try_into_val(&env).unwrap();
+
+    assert_eq!(event_topic, symbol_short!("upgrade"));
+    assert_eq!(event_wasm_hash, new_wasm_hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_upgrade_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+
+    // Mock only the non-admin authorization, admin should not be authorized
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let new_wasm_hash = BytesN::from_array(&env, &[42u8; 32]);
+    // This should panic because non_admin is not the admin
+    client.upgrade(&new_wasm_hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_upgrade_before_init_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    let new_wasm_hash = BytesN::from_array(&env, &[42u8; 32]);
+    client.upgrade(&new_wasm_hash);
+}


### PR DESCRIPTION
**Summary**
- Emit an audit event containing the requested WASM hash when an admin triggers `upgrade()`; add unit tests and include the event schema for operators.

**Motivation**
- `upgrade()` is a privileged admin operation. Emitting a pre-upgrade audit event improves observability and allows operators/monitors to detect and validate proactive upgrade intentions before WASM is swapped.

**Changes**
- admin.rs: Added `upgrade(e: Env, new_wasm_hash: BytesN<32>)` which:
  - requires current admin authorization,
  - publishes an `upgrade` event with the requested WASM hash prior to performing the upgrade,
  - calls the deployer API to apply the WASM update.
- lib.rs: Exposed `upgrade()` on the public contract interface.
- test.rs: Added tests:
  - `test_upgrade_emits_event` — verifies the `upgrade` event is emitted and contains the requested hash.
  - `test_upgrade_requires_admin_auth` — verifies admin authorization is required.
  - `test_upgrade_before_init_fails` — verifies upgrade before initialization fails.

**Event schema (for operators)**
- Event name (topic 0): Symbol `upgrade`
- Topics: ( `upgrade` )
- Data payload: `BytesN<32>` — the requested WASM hash (sha256 of uploaded WASM blob)
- Emission timing: published immediately before the contract calls the deployer to update WASM.

Example event shape (semantic):
- Topics: [`upgrade`]
- Data: `<wasm_hash: BytesN<32>>`

Operators can watch for `upgrade` events and validate that:
- the listed WASM hash matches an uploaded blob they expect,
- the caller is the recorded admin address (via usual monitoring of transaction authorization).

**Testing**
- Run the contract unit tests:
```bash
cargo test --lib
```
- Or run only the new tests:
```bash
cargo test --lib test_upgrade_emits_event test_upgrade_requires_admin_auth test_upgrade_before_init_fails
```

**Notes & Compatibility**
- The event is emitted before invoking the deployer to update the contract WASM so off-chain observers can react before the code swap occurs.
- This change is backwards-compatible for callers (adds a new public method `upgrade` exposed from the contract).
- I included the event schema here to ensure operators can be updated immediately; if you prefer, I can add a short section to the repo docs describing the schema and monitoring recommendations.

**Checklist**
- [x] Emit event containing requested WASM hash before upgrade
- [x] Add tests for event emission and admin authorization
- [ ] Add repository documentation page describing the `upgrade` event schema (optional — I can add this in a follow-up commit)

**Suggested commit message**
feat(security): emit audit event for admin `upgrade` and add tests

Closes #270