### PR TITLE
refactor/build: shared test helper, admin reader, migration guard, pinned toolchain (#291, #292, #293, #294)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.77-slim
+FROM rust:1.94-slim
 
 RUN rustup target add wasm32-unknown-unknown
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The contract is split into focused modules:
 - `src/queries.rs`: read-only queries and metadata
 - `src/errors.rs`: contract error codes
 - `src/storage_types.rs`: storage keys and persisted record types
+- `src/test_utils.rs`: shared test-only helpers (e.g. payload signing)
 
 ## Data model
 
@@ -36,6 +37,7 @@ Each wrap record stores:
 - `DataKey::Wrap(Address, u64)`
 - `DataKey::WrapCount(Address)`
 - `DataKey::LatestPeriod(Address)`
+- `DataKey::MigrationVersion`
 
 ## Public interface
 
@@ -44,6 +46,7 @@ Each wrap record stores:
 - `initialize(e: Env, admin: Address, admin_pubkey: BytesN<32>)`
 - `update_admin(e: Env, new_admin: Address)`
 - `mint_wrap(e: Env, user: Address, period: u64, archetype: Symbol, data_hash: BytesN<32>, signature: BytesN<64>)`
+- `migrate(e: Env, version: u32)`
 
 ### Read methods
 
@@ -55,6 +58,7 @@ Each wrap record stores:
 - `name(e: Env) -> String`
 - `symbol(e: Env) -> String`
 - `decimals(e: Env) -> u32`
+- `migration_version(e: Env) -> u32`
 
 ## Event schema
 
@@ -88,10 +92,32 @@ Recommended aggregation rule:
 3. count events per user
 4. sort descending by count to produce the leaderboard
 
+## Upgrade compatibility
+
+An upgrade replaces contract code while keeping storage, so any change to the
+storage layout must ship as a numbered migration:
+
+- `DataKey::MigrationVersion` stores the highest migration version applied (`0` before any migration).
+- `migrate(version)` is admin-only and only accepts a version greater than the stored one, so a
+  migration can never run twice — a replay panics with `MigrationAlreadyApplied` (#7).
+- Additive changes (new `DataKey` variants, new methods) need no migration; changing or removing
+  the shape of an existing key does, and the new code must bump the migration version.
+- Call `migrate` in the same transaction batch as the upgrade, and verify with `migration_version()`.
+
 ## Development
+
+The toolchain is pinned in `rust-toolchain.toml` (Rust 1.94.1 with the
+`wasm32-unknown-unknown` target), so local, Docker, and CI builds match. With
+`rustup` installed, the correct toolchain is selected automatically.
 
 Run the test suite with:
 
 ```bash
 cargo test
+```
+
+Build the WASM artifact with:
+
+```bash
+cargo build --release --target wasm32-unknown-unknown
 ```

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.94.1"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]
+profile = "minimal"

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -2,6 +2,14 @@ use soroban_sdk::{panic_with_error, Address, BytesN, Env};
 
 use crate::{ContractError, DataKey};
 
+/// Reads the stored admin or panics with `NotInitialized`.
+pub(crate) fn read_admin(e: &Env) -> Address {
+    e.storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized))
+}
+
 pub(crate) fn initialize(e: Env, admin: Address, admin_pubkey: BytesN<32>) {
     if e.storage().instance().has(&DataKey::Admin) {
         panic_with_error!(e, ContractError::AlreadyInitialized);
@@ -13,12 +21,29 @@ pub(crate) fn initialize(e: Env, admin: Address, admin_pubkey: BytesN<32>) {
 }
 
 pub(crate) fn update_admin(e: Env, new_admin: Address) {
-    let current_admin: Address = e
-        .storage()
-        .instance()
-        .get(&DataKey::Admin)
-        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
-
-    current_admin.require_auth();
+    read_admin(&e).require_auth();
     e.storage().instance().set(&DataKey::Admin, &new_admin);
+}
+
+/// Marks a storage migration as applied. A version can only be applied once and
+/// versions must move forward, so an upgrade shipping a migration cannot corrupt
+/// storage by replaying it.
+pub(crate) fn migrate(e: Env, version: u32) {
+    read_admin(&e).require_auth();
+
+    let applied = migration_version(&e);
+    if version <= applied {
+        panic_with_error!(e, ContractError::MigrationAlreadyApplied);
+    }
+
+    e.storage()
+        .instance()
+        .set(&DataKey::MigrationVersion, &version);
+}
+
+pub(crate) fn migration_version(e: &Env) -> u32 {
+    e.storage()
+        .instance()
+        .get(&DataKey::MigrationVersion)
+        .unwrap_or(0)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,4 +10,5 @@ pub enum ContractError {
     WrapAlreadyExists = 4,
     InvalidSignature = 5,
     InvalidPeriod = 6,
+    MigrationAlreadyApplied = 7,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+#[cfg(test)]
+extern crate std;
+
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, Symbol};
 
 mod admin;
@@ -22,6 +25,16 @@ impl StellarWrapContract {
 
     pub fn update_admin(e: Env, new_admin: Address) {
         admin::update_admin(e, new_admin);
+    }
+
+    /// Records that the storage migration `version` has been applied.
+    /// Admin-only, and each version can only be applied once.
+    pub fn migrate(e: Env, version: u32) {
+        admin::migrate(e, version);
+    }
+
+    pub fn migration_version(e: Env) -> u32 {
+        admin::migration_version(&e)
     }
 
     pub fn mint_wrap(
@@ -72,3 +85,5 @@ impl StellarWrapContract {
 mod security_test;
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod test_utils;

--- a/src/security_test.rs
+++ b/src/security_test.rs
@@ -6,38 +6,14 @@
 //! cross-contract replay protection, and resource consumption.
 
 use super::*;
-use ed25519_dalek::{Signer, SigningKey};
+use crate::test_utils::sign_payload;
+use ed25519_dalek::SigningKey;
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Ledger},
-    xdr::ToXdr,
-    Address, Bytes, BytesN, Env, Symbol,
+    Address, BytesN, Env,
 };
 
-/// Helper function to sign payloads for testing
-fn sign_payload(
-    env: &Env,
-    signer: &SigningKey,
-    contract: &Address,
-    user: &Address,
-    period: u64,
-    archetype: &Symbol,
-    data_hash: &BytesN<32>,
-) -> BytesN<64> {
-    let mut payload = Bytes::new(env);
-    payload.append(&contract.to_xdr(env));
-    payload.append(&user.clone().to_xdr(env));
-    payload.append(&period.to_xdr(env));
-    payload.append(&archetype.clone().to_xdr(env));
-    payload.append(&data_hash.clone().to_xdr(env));
-
-    let mut out = [0u8; 512];
-    let len = payload.len() as usize;
-    payload.copy_into_slice(&mut out[..len]);
-
-    let signature = signer.sign(&out[..len]);
-    BytesN::from_array(env, &signature.to_bytes())
-}
 
 /// Test 1: Replay Attack Simulation
 /// Ensures that a valid signature cannot be reused for the same period

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -22,4 +22,6 @@ pub enum DataKey {
     WrapCount(Address),
     /// Stores the latest period minted for a specific user.
     LatestPeriod(Address),
+    /// Stores the highest storage migration version already applied.
+    MigrationVersion,
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,40 +3,17 @@
 extern crate std;
 
 use super::*;
-use ed25519_dalek::{Signer, SigningKey};
+use crate::test_utils::sign_payload;
+use ed25519_dalek::SigningKey;
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events},
-    xdr::ToXdr,
     Address, Bytes, BytesN, Env, String, Symbol, TryIntoVal,
 };
 use std::vec::Vec;
 
 const STRESS_USER_COUNT: usize = 128;
 
-fn sign_payload(
-    env: &Env,
-    signer: &SigningKey,
-    contract: &Address,
-    user: &Address,
-    period: u64,
-    archetype: &Symbol,
-    data_hash: &BytesN<32>,
-) -> BytesN<64> {
-    let mut payload = Bytes::new(env);
-    payload.append(&contract.to_xdr(env));
-    payload.append(&user.clone().to_xdr(env));
-    payload.append(&period.to_xdr(env));
-    payload.append(&archetype.clone().to_xdr(env));
-    payload.append(&data_hash.clone().to_xdr(env));
-
-    let mut out = [0u8; 512];
-    let len = payload.len() as usize;
-    payload.copy_into_slice(&mut out[..len]);
-
-    let signature = signer.sign(&out[..len]);
-    BytesN::from_array(env, &signature.to_bytes())
-}
 
 #[test]
 fn test_minting_flow() {
@@ -661,4 +638,53 @@ fn test_get_admin_before_init_returns_none() {
     let client = StellarWrapContractClient::new(&env, &contract_id);
 
     assert!(client.get_admin().is_none());
+}
+
+#[test]
+fn test_migrate_applies_once_per_version() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    assert_eq!(client.migration_version(), 0);
+
+    client.migrate(&1);
+    assert_eq!(client.migration_version(), 1);
+
+    client.migrate(&2);
+    assert_eq!(client.migration_version(), 2);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_migrate_rejects_replay() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.migrate(&1);
+    client.migrate(&1);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_migrate_before_init_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    client.migrate(&1);
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,29 @@
+#![cfg(test)]
+
+use ed25519_dalek::{Signer, SigningKey};
+use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env, Symbol};
+
+/// Signs the same payload layout the contract rebuilds in `mint::mint_wrap`.
+pub(crate) fn sign_payload(
+    env: &Env,
+    signer: &SigningKey,
+    contract: &Address,
+    user: &Address,
+    period: u64,
+    archetype: &Symbol,
+    data_hash: &BytesN<32>,
+) -> BytesN<64> {
+    let mut payload = Bytes::new(env);
+    payload.append(&contract.to_xdr(env));
+    payload.append(&user.clone().to_xdr(env));
+    payload.append(&period.to_xdr(env));
+    payload.append(&archetype.clone().to_xdr(env));
+    payload.append(&data_hash.clone().to_xdr(env));
+
+    let mut out = [0u8; 512];
+    let len = payload.len() as usize;
+    payload.copy_into_slice(&mut out[..len]);
+
+    let signature = signer.sign(&out[..len]);
+    BytesN::from_array(env, &signature.to_bytes())
+}


### PR DESCRIPTION
Closes #291, closes #292, closes #293, closes #294.

Four small, independent changes in one branch:

**#292 — shared test signing helper**
`sign_payload` was duplicated in `src/test.rs` and `src/security_test.rs`. It now lives in a test-only `src/test_utils.rs` and both files import it. No test behavior changed.

**#294 — admin reader helper**
Added `admin::read_admin(&Env) -> Address`, which panics with `NotInitialized` when the admin key is absent. `update_admin` (and the new `migrate`) use it. Public behavior is unchanged — `update_admin` before init still panics with `Error(Contract, #2)`.

**#291 — migration guard**
- New storage key `DataKey::MigrationVersion` holding the highest applied migration version (`0` before any migration).
- New admin-only `migrate(version: u32)`: requires admin auth and only accepts a version strictly greater than the stored one, so a migration cannot be replayed. Replay panics with the new `MigrationAlreadyApplied` (#7).
- New read method `migration_version() -> u32`.
- README gains an "Upgrade compatibility" section describing when a migration is required and how to run one alongside an upgrade.
- Tests: forward-only application, replay rejection, and calling before initialization.

**#293 — pinned toolchain**
- `rust-toolchain.toml` pinning Rust `1.94.1` with the `wasm32-unknown-unknown` target (and rustfmt/clippy).
- `Dockerfile` bumped from `rust:1.77-slim` to match. Note: with the current dependency graph the crate no longer builds on 1.77/1.85 — transitive deps (`darling`, `serde_with`) require rustc ≥ 1.88 — so the pin also unbreaks the Docker build.
- README quickstart documents the pin and the WASM build command.

**One extra fix required to build:** `#[cfg(test)] extern crate std;` in `src/lib.rs`. Without it the `#[contracttype]` types in `src/storage_types.rs` fail to compile under `cargo test`, because the SDK's testutils `Arbitrary` derive emits `std` paths at the definition site. This failure exists on `main` too (there is no committed `Cargo.lock`).

**Verification**
- `cargo test` — 34 passed, 0 failed, no warnings.
- `cargo build --release --target wasm32-unknown-unknown` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)