### PR TITLE
feat(contract): add compact contract health/status read method

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Each wrap record stores:
 - year must be between `2024` and `2100`
 - month must be between `01` and `12`
 
+### `ContractHealth`
+
+Returned by `health()`, reports:
+
+- `initialized: bool` — whether `initialize()` has been called
+- `has_admin: bool` — whether an admin address is currently configured
+- `has_signing_key: bool` — whether an admin signing key is currently configured
+
 ## Storage keys
 
 - `DataKey::Admin`
@@ -52,6 +60,7 @@ Each wrap record stores:
 - `verify_data(e: Env, user: Address, period: u64, data: Bytes) -> bool`
 - `get_latest_wrap(e: Env, user: Address) -> Option<WrapRecord>`
 - `get_admin(e: Env) -> Option<Address>`
+- `health(e: Env) -> ContractHealth`
 - `name(e: Env) -> String`
 - `symbol(e: Env) -> String`
 - `decimals(e: Env) -> u32`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+#[cfg(test)]
+extern crate std;
+
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, Symbol};
 
 mod admin;
@@ -9,7 +12,7 @@ mod queries;
 mod storage_types;
 
 pub use errors::ContractError;
-pub use storage_types::{DataKey, WrapRecord};
+pub use storage_types::{ContractHealth, DataKey, WrapRecord};
 
 #[contract]
 pub struct StellarWrapContract;
@@ -53,6 +56,10 @@ impl StellarWrapContract {
 
     pub fn get_admin(e: Env) -> Option<Address> {
         queries::get_admin(e)
+    }
+
+    pub fn health(e: Env) -> ContractHealth {
+        queries::health(e)
     }
 
     pub fn name(e: Env) -> String {

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,6 +1,5 @@
+use crate::{ContractHealth, DataKey, WrapRecord};
 use soroban_sdk::{Address, Bytes, BytesN, Env, String};
-
-use crate::{DataKey, WrapRecord};
 
 pub(crate) fn get_wrap(e: Env, user: Address, period: u64) -> Option<WrapRecord> {
     e.storage().persistent().get(&DataKey::Wrap(user, period))
@@ -30,6 +29,17 @@ pub(crate) fn get_latest_wrap(e: Env, user: Address) -> Option<WrapRecord> {
     let latest_key = DataKey::LatestPeriod(user.clone());
     let period: u64 = e.storage().persistent().get(&latest_key)?;
     e.storage().persistent().get(&DataKey::Wrap(user, period))
+}
+
+pub(crate) fn health(e: Env) -> ContractHealth {
+    let has_admin = e.storage().instance().has(&DataKey::Admin);
+    let has_signing_key = e.storage().instance().has(&DataKey::AdminPubKey);
+
+    ContractHealth {
+        initialized: has_admin,
+        has_admin,
+        has_signing_key,
+    }
 }
 
 pub(crate) fn get_admin(e: Env) -> Option<Address> {

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+extern crate std;
 use soroban_sdk::{contracttype, Address, BytesN, Symbol};
 
 #[contracttype]
@@ -7,6 +9,17 @@ pub struct WrapRecord {
     pub data_hash: BytesN<32>,
     pub archetype: Symbol,
     pub period: u64, // Standardized to u64 for better indexing/sorting
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContractHealth {
+    /// Whether `initialize()` has been called (admin address is set).
+    pub initialized: bool,
+    /// Whether an admin address is currently configured.
+    pub has_admin: bool,
+    /// Whether an admin signing (public) key is currently configured.
+    pub has_signing_key: bool,
 }
 
 #[contracttype]

--- a/src/test.rs
+++ b/src/test.rs
@@ -171,6 +171,31 @@ fn test_initialize_twice_fails() {
 }
 
 #[test]
+fn test_health_reflects_initialization_state() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    // Before initialization: nothing configured.
+    let health = client.health();
+    assert_eq!(health.initialized, false);
+    assert_eq!(health.has_admin, false);
+    assert_eq!(health.has_signing_key, false);
+
+    // Initialize the contract.
+    let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &admin_pubkey);
+
+    // After initialization: everything configured.
+    let health = client.health();
+    assert_eq!(health.initialized, true);
+    assert_eq!(health.has_admin, true);
+    assert_eq!(health.has_signing_key, true);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #4)")]
 fn test_duplicate_period_fails() {
     let env = Env::default();


### PR DESCRIPTION
Adds health() returning ContractHealth (initialized, has_admin, has_signing_key) so clients can check contract readiness without knowing the storage layout. Includes tests before/after initialization and documents the output fields in the README.

Closes #289 