### PR TITLE
feat(#268): add revoke_wrap with reason_hash for audit trail

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -18,18 +18,14 @@ The codes are defined by the Rust `ContractError` enum in `src/lib.rs`.
 - Reentrancy guard indicates an unexpected execution pattern / guard collision | 1) For admin-only functions (`update_wrap`, `revoke_wrap`, `upgrade`), ensure the call includes admin authorization. 2) For `mint_wrap`, ensure the `user` parameter is the address authorizing the call.
 3) If you are seeing this during retries, check for concurrent calls or repeated invocations that might trip the temporary mint guard. |
 | 4 | `WrapAlreadyExists` | A wrap record already exists for the `(user, period)` pair | Retrying the same mint, or attempting to mint twice for same user+period | 1) Check whether `get_wrap(user, period)` already returns a record. 2) If your UI retries, make the client idempotent. 3) If you intended a new wrap, use a new `period`. |
-| 5 | `WrapNotFound` | A wrap record was not found for the `(user, period)` pair | Revoking/updating a wrap that never existed, or period mismatch | 1) Use `get_wrap(user, period)` to confirm existence. 2) Ensure you are passing the exact same `period` value used when the wrap was minted. 3) If the record may have been revoked, mint again or fetch the correct period. |
-| 6 | `InvalidSignature` | Ed25519 signature verification failed against the contract’s admin public key | - Wrong signature for the payload
+| 5 | `InvalidSignature` | Ed25519 signature verification failed against the contract's admin public key | - Wrong signature for the payload
 - Wrong `contract_id` / payload fields
-- Signature generated for a different user/period/archetype/data_hash | 1) Regenerate the signature using the correct canonical payload (see “Payload & signing notes” below).
+- Signature generated for a different user/period/archetype/data_hash | 1) Regenerate the signature using the correct canonical payload (see "Payload & signing notes" below).
 2) Confirm the signature corresponds to the correct contract instance (`contract_id` / `current_contract_address()`).
 3) Confirm you sign for the correct `user`, `period`, `archetype`, and `data_hash`.
 4) Ensure you pass the 64-byte signature bytes (not base64/hex-decoded to the wrong length). |
-| 7 | `InvalidDataHash` | `data_hash` is all-zero bytes (missing/invalid data) | Passing `0x00…00` as `data_hash` | 1) Compute `data_hash = sha256(original_json_bytes)`.
-2) Ensure you don’t initialize `data_hash` with a zero placeholder.
-3) Validate the off-chain JSON bytes are the same bytes you intend to mint. |
-| 8 | `UserOptedOut` | The user has opted out of receiving future wraps | Calling `mint_wrap` or `mint_campaign_wrap` for an opted-out user | 1) Ask the user to call `opt_in()` to re-enable mints.
-2) Check opt-out status before attempting to mint. |
+| 6 | `InvalidPeriod` | The period value is malformed or out of range | Period does not follow `YYYYMM` format (year 2024–2100, month 01–12) | Ensure `period` uses a valid year (2024–2100) and month (01–12). |
+| 7 | `WrapNotFound` | A wrap record was not found for the `(user, period)` pair | Revoking a wrap that never existed, or period mismatch | 1) Use `get_wrap(user, period)` to confirm existence. 2) Ensure you are passing the exact same `period` value used when the wrap was minted. 3) If the record may have been revoked, mint again or fetch the correct period. |
 
 ---
 
@@ -61,24 +57,19 @@ thread 'main' panicked at 'Error(Contract, #3)'
 thread 'main' panicked at 'Error(Contract, #4)'
 ```
 
-### Code 5 — `WrapNotFound`
+### Code 5 — `InvalidSignature`
 ```text
 thread 'main' panicked at 'Error(Contract, #5)'
 ```
 
-### Code 6 — `InvalidSignature`
+### Code 6 — `InvalidPeriod`
 ```text
 thread 'main' panicked at 'Error(Contract, #6)'
 ```
 
-### Code 7 — `InvalidDataHash`
+### Code 7 — `WrapNotFound`
 ```text
 thread 'main' panicked at 'Error(Contract, #7)'
-```
-
-### Code 8 — `UserOptedOut`
-```text
-thread 'main' panicked at 'Error(Contract, #8)'
 ```
 
 ---
@@ -113,12 +104,12 @@ If your CLI/tooling shows a different wording around an Ed25519 verify failure, 
 ## Troubleshooting tips (fast)
 
 - If you see **`Error(Contract, #3)`**, check that:
-  - You are calling admin-only functions from the **admin address** (or providing the correct authorization).
+  - You are calling admin-only functions (`update_admin`, `revoke_wrap`) from the **admin address** (or providing the correct authorization).
   - The `user` provided to `mint_wrap` is the same address that authorizes the call.
-  - You’re not issuing concurrent/repeated invocations that trip the temporary mint guard.
 - If you see **`Error(Contract, #4)`**, check whether you already minted `(user, period)` with `get_wrap(user, period)`.
-- If you see **`Error(Contract, #5)`**, verify `period` matches the minted period exactly.
-- If you see **`Error(Contract, #8)`**, the user has opted out of receiving wraps. Ask them to call `opt_in()` to re-enable mints.
+- If you see **`Error(Contract, #5)`**, verify your Ed25519 signature and canonical payload encoding.
+- If you see **`Error(Contract, #6)`**, ensure `period` follows `YYYYMM` format (year 2024–2100, month 01–12).
+- If you see **`Error(Contract, #7)`**, the wrap record does not exist. Use `get_wrap(user, period)` to confirm or mint a new wrap.
 
 ---
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,4 +10,5 @@ pub enum ContractError {
     WrapAlreadyExists = 4,
     InvalidSignature = 5,
     InvalidPeriod = 6,
+    WrapNotFound = 7,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod admin;
 mod errors;
 mod mint;
 mod queries;
+mod revoke;
 mod storage_types;
 
 pub use errors::ContractError;
@@ -65,6 +66,10 @@ impl StellarWrapContract {
 
     pub fn decimals(e: Env) -> u32 {
         queries::decimals(e)
+    }
+
+    pub fn revoke_wrap(e: Env, user: Address, period: u64, reason_hash: BytesN<32>) {
+        revoke::revoke_wrap(e, user, period, reason_hash);
     }
 }
 

--- a/src/revoke.rs
+++ b/src/revoke.rs
@@ -1,0 +1,72 @@
+use soroban_sdk::{panic_with_error, symbol_short, Address, BytesN, Env};
+
+use crate::{ContractError, DataKey};
+
+/// Revokes an existing wrap record for the given user and period.
+///
+/// # Authorization
+/// Only the contract admin can revoke wraps. The caller must provide admin
+/// authorization via `require_auth()`.
+///
+/// # reason_hash
+/// An optional SHA-256 hash of an off-chain revocation reason. This allows
+/// auditors to link a revocation to off-chain evidence (e.g., a governance
+/// vote, dispute resolution, or compliance action) without exposing private
+/// data on-chain. Pass a zero-filled `BytesN<32>` to omit the reason.
+///
+/// # Privacy Considerations
+/// - The `reason_hash` is a one-way hash. It cannot be reversed to reveal the
+///   original reason, preserving confidentiality of sensitive decisions.
+/// - Evidence handling: the off-chain reason should be stored in a verifiable
+///   location (e.g., a signed document, IPFS, or a governance log) so that
+///   auditors can recompute the hash and confirm it matches the on-chain value.
+/// - If no reason is provided (all-zero hash), the event still emits for
+///   transparency, but without a link to off-chain evidence.
+pub(crate) fn revoke_wrap(
+    e: Env,
+    user: Address,
+    period: u64,
+    reason_hash: BytesN<32>,
+) {
+    let admin: Address = e
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+    admin.require_auth();
+
+    let wrap_key = DataKey::Wrap(user.clone(), period);
+
+    if !e.storage().persistent().has(&wrap_key) {
+        panic_with_error!(e, ContractError::WrapNotFound);
+    }
+
+    // Remove the wrap record
+    e.storage().persistent().remove(&wrap_key);
+
+    // Decrement the user's wrap count
+    let count_key = DataKey::WrapCount(user.clone());
+    let current_count: u32 = e
+        .storage()
+        .persistent()
+        .get(&count_key)
+        .unwrap_or(0);
+
+    if current_count > 0 {
+        e.storage()
+            .persistent()
+            .set(&count_key, &(current_count - 1));
+    }
+
+    // Clear latest period if we just revoked it
+    let latest_key = DataKey::LatestPeriod(user.clone());
+    let current_latest: Option<u64> = e.storage().persistent().get(&latest_key);
+    if current_latest == Some(period) {
+        e.storage().persistent().remove(&latest_key);
+    }
+
+    // Emit revoke event with reason_hash for audit trail
+    e.events()
+        .publish((symbol_short!("revoke"), user, period), reason_hash);
+}

--- a/src/security_test.rs
+++ b/src/security_test.rs
@@ -605,3 +605,25 @@ fn test_non_admin_cannot_mint() {
     // This should panic because attacker is not authorized
     client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
 }
+
+/// Test 11: Revocation - Non-admin cannot revoke wraps
+/// Only the admin should be able to revoke wrap records.
+/// Without any mocked auth, admin.require_auth() will panic.
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_revoke() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+
+    // Do NOT mock any auths — admin.require_auth() should panic
+    let reason_hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.revoke_wrap(&user, &202512, &reason_hash);
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -662,3 +662,271 @@ fn test_get_admin_before_init_returns_none() {
 
     assert!(client.get_admin().is_none());
 }
+
+// ── Revocation Tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn test_revoke_wrap_success() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[15u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 202401u64;
+    let signature = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash,
+    );
+    client.mint_wrap(&user, &period, &archetype, &hash, &signature);
+    assert_eq!(client.balance_of(&user), 1);
+    assert!(client.get_wrap(&user, &period).is_some());
+
+    let reason_hash = BytesN::from_array(&env, &[1u8; 32]);
+    client.revoke_wrap(&user, &period, &reason_hash);
+
+    assert!(client.get_wrap(&user, &period).is_none());
+    assert_eq!(client.balance_of(&user), 0);
+}
+
+#[test]
+fn test_revoke_wrap_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[16u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 202401u64;
+    let signature = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash,
+    );
+    client.mint_wrap(&user, &period, &archetype, &hash, &signature);
+
+    let reason_hash = BytesN::from_array(&env, &[0xAAu8; 32]);
+    client.revoke_wrap(&user, &period, &reason_hash);
+
+    let events = env.events().all();
+    let last_event = events.last().expect("no events found");
+    let (_, topics, data) = last_event;
+
+    let event_topic: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let event_user: Address = topics.get(1).unwrap().try_into_val(&env).unwrap();
+    let event_period: u64 = topics.get(2).unwrap().try_into_val(&env).unwrap();
+    let event_reason: BytesN<32> = data.try_into_val(&env).unwrap();
+
+    assert_eq!(event_topic, symbol_short!("revoke"));
+    assert_eq!(event_user, user);
+    assert_eq!(event_period, period);
+    assert_eq!(event_reason, reason_hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_revoke_wrap_not_found_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    let user = Address::generate(&env);
+    let reason_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+    client.revoke_wrap(&user, &202401, &reason_hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_revoke_wrap_before_init_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    let user = Address::generate(&env);
+    let reason_hash = BytesN::from_array(&env, &[0u8; 32]);
+
+    client.revoke_wrap(&user, &202401, &reason_hash);
+}
+
+#[test]
+fn test_revoke_latest_period_clears_latest() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[17u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let archetype = symbol_short!("arch");
+    let hash1 = BytesN::from_array(&env, &[10u8; 32]);
+    let hash2 = BytesN::from_array(&env, &[20u8; 32]);
+
+    let sig1 = sign_payload(
+        &env, &signing_key, &contract_id, &user, 202401, &archetype, &hash1,
+    );
+    let sig2 = sign_payload(
+        &env, &signing_key, &contract_id, &user, 202402, &archetype, &hash2,
+    );
+
+    client.mint_wrap(&user, &202401, &archetype, &hash1, &sig1);
+    client.mint_wrap(&user, &202402, &archetype, &hash2, &sig2);
+
+    let latest = client.get_latest_wrap(&user).unwrap();
+    assert_eq!(latest.period, 202402);
+
+    let reason_hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.revoke_wrap(&user, &202402, &reason_hash);
+
+    // LatestPeriod was cleared; get_latest_wrap returns None
+    assert!(client.get_latest_wrap(&user).is_none());
+    assert_eq!(client.balance_of(&user), 1);
+}
+
+#[test]
+fn test_revoke_non_latest_preserves_latest() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[18u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let archetype = symbol_short!("arch");
+    let hash1 = BytesN::from_array(&env, &[10u8; 32]);
+    let hash2 = BytesN::from_array(&env, &[20u8; 32]);
+
+    let sig1 = sign_payload(
+        &env, &signing_key, &contract_id, &user, 202401, &archetype, &hash1,
+    );
+    let sig2 = sign_payload(
+        &env, &signing_key, &contract_id, &user, 202403, &archetype, &hash2,
+    );
+
+    client.mint_wrap(&user, &202401, &archetype, &hash1, &sig1);
+    client.mint_wrap(&user, &202403, &archetype, &hash2, &sig2);
+
+    let reason_hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.revoke_wrap(&user, &202401, &reason_hash);
+
+    // Latest period (202403) should still be retrievable
+    let latest = client.get_latest_wrap(&user).unwrap();
+    assert_eq!(latest.period, 202403);
+    assert_eq!(client.balance_of(&user), 1);
+}
+
+#[test]
+fn test_remint_after_revoke_succeeds() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[19u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let archetype = symbol_short!("arch");
+    let hash1 = BytesN::from_array(&env, &[10u8; 32]);
+    let hash2 = BytesN::from_array(&env, &[20u8; 32]);
+    let period = 202401u64;
+
+    let sig1 = sign_payload(
+        &env, &signing_key, &contract_id, &user, period, &archetype, &hash1,
+    );
+    client.mint_wrap(&user, &period, &archetype, &hash1, &sig1);
+
+    let reason_hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.revoke_wrap(&user, &period, &reason_hash);
+
+    // Should be able to mint a new wrap for the same period after revocation
+    let sig2 = sign_payload(
+        &env, &signing_key, &contract_id, &user, period, &archetype, &hash2,
+    );
+    client.mint_wrap(&user, &period, &archetype, &hash2, &sig2);
+
+    let wrap = client.get_wrap(&user, &period).unwrap();
+    assert_eq!(wrap.data_hash, hash2);
+    assert_eq!(client.balance_of(&user), 1);
+}
+
+#[test]
+fn test_revoke_with_zero_reason_hash() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[20u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 202401u64;
+    let signature = sign_payload(
+        &env, &signing_key, &contract_id, &user, period, &archetype, &hash,
+    );
+    client.mint_wrap(&user, &period, &archetype, &hash, &signature);
+
+    // Zero reason hash (no reason provided)
+    let reason_hash = BytesN::from_array(&env, &[0u8; 32]);
+    client.revoke_wrap(&user, &period, &reason_hash);
+
+    assert!(client.get_wrap(&user, &period).is_none());
+    assert_eq!(client.balance_of(&user), 0);
+
+    // Verify the event still emitted with zero hash
+    let events = env.events().all();
+    let last_event = events.last().expect("no events found");
+    let (_, _, data) = last_event;
+    let event_reason: BytesN<32> = data.try_into_val(&env).unwrap();
+    assert_eq!(event_reason, reason_hash);
+}


### PR DESCRIPTION
closes #268 
- Add WrapNotFound (code 7) error variant
- Implement revoke_wrap(user, period, reason_hash) in new revoke module
- Admin-only: requires admin authorization via require_auth()
- reason_hash supports audit linking to off-chain evidence (zero hash = no reason)
- Removes wrap, decrements WrapCount, clears LatestPeriod if revoked
- Emits revoke event with (user, period, reason_hash)
- Add 9 tests: success, events, errors, latest period, re-mint, zero hash, non-admin rejection
- Update ERRORS.md to match actual error code ordering

Closes #268