### PR TITLE
Feature/add total revoked counter

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{panic_with_error, Address, BytesN, Env};
+use soroban_sdk::{panic_with_error, symbol_short, Address, BytesN, Env};
 
 use crate::{ContractError, DataKey};
 
@@ -21,4 +21,21 @@ pub(crate) fn update_admin(e: Env, new_admin: Address) {
 
     current_admin.require_auth();
     e.storage().instance().set(&DataKey::Admin, &new_admin);
+}
+
+pub(crate) fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
+    let current_admin: Address = e
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+    current_admin.require_auth();
+
+    // Emit audit event with the requested WASM hash before performing the upgrade
+    e.events()
+        .publish((symbol_short!("upgrade"),), new_wasm_hash.clone());
+
+    // Update the contract WASM with the provided hash
+    e.deployer().update_current_contract_wasm(new_wasm_hash);
 }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -39,3 +39,33 @@ pub(crate) fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
     // Update the contract WASM with the provided hash
     e.deployer().update_current_contract_wasm(new_wasm_hash);
 }
+
+pub(crate) fn revoke_wrap(e: Env, user: Address, period: u64) {
+    let current_admin: Address = e
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+    current_admin.require_auth();
+
+    let wrap_key = DataKey::Wrap(user.clone(), period);
+    if !e.storage().persistent().has(&wrap_key) {
+        panic_with_error!(e, ContractError::WrapNotFound);
+    }
+
+    e.storage().persistent().remove(&wrap_key);
+
+    let count_key = DataKey::WrapCount(user.clone());
+    let current_count: u32 = e.storage().persistent().get(&count_key).unwrap_or(0);
+    let next_count = current_count.saturating_sub(1);
+    e.storage().persistent().set(&count_key, &next_count);
+
+    let total_revoked_key = DataKey::TotalRevoked;
+    let current_total: u64 = e.storage().instance().get(&total_revoked_key).unwrap_or(0);
+    let next_total = current_total + 1;
+    e.storage().instance().set(&total_revoked_key, &next_total);
+
+    e.events()
+        .publish((symbol_short!("revoke"), user, period), ());
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,4 +10,5 @@ pub enum ContractError {
     WrapAlreadyExists = 4,
     InvalidSignature = 5,
     InvalidPeriod = 6,
+    WrapNotFound = 7,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,14 @@ impl StellarWrapContract {
         mint::mint_wrap(e, user, period, archetype, data_hash, signature);
     }
 
+    pub fn revoke_wrap(e: Env, user: Address, period: u64) {
+        admin::revoke_wrap(e, user, period);
+    }
+
+    pub fn total_revoked(e: Env) -> u64 {
+        queries::total_revoked(e)
+    }
+
     pub fn get_wrap(e: Env, user: Address, period: u64) -> Option<WrapRecord> {
         queries::get_wrap(e, user, period)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,10 @@ impl StellarWrapContract {
         admin::update_admin(e, new_admin);
     }
 
+    pub fn upgrade(e: Env, new_wasm_hash: BytesN<32>) {
+        admin::upgrade(e, new_wasm_hash);
+    }
+
     pub fn mint_wrap(
         e: Env,
         user: Address,

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -36,6 +36,13 @@ pub(crate) fn get_admin(e: Env) -> Option<Address> {
     e.storage().instance().get(&DataKey::Admin)
 }
 
+pub(crate) fn total_revoked(e: Env) -> u64 {
+    e.storage()
+        .instance()
+        .get::<_, u64>(&DataKey::TotalRevoked)
+        .unwrap_or(0)
+}
+
 pub(crate) fn name(e: Env) -> String {
     String::from_str(&e, "Stellar Wrap Registry")
 }

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -22,4 +22,6 @@ pub enum DataKey {
     WrapCount(Address),
     /// Stores the latest period minted for a specific user.
     LatestPeriod(Address),
+    /// Stores the total number of wrap records revoked on-chain.
+    TotalRevoked,
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -662,3 +662,60 @@ fn test_get_admin_before_init_returns_none() {
 
     assert!(client.get_admin().is_none());
 }
+
+#[test]
+fn test_upgrade_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    let new_wasm_hash = BytesN::from_array(&env, &[42u8; 32]);
+    client.upgrade(&new_wasm_hash);
+
+    let events = env.events().all();
+    let last_event = events.last().expect("no events found");
+    let (_, topics, data) = last_event;
+
+    let event_topic: Symbol = topics.get(0).unwrap().try_into_val(&env).unwrap();
+    let event_wasm_hash: BytesN<32> = data.try_into_val(&env).unwrap();
+
+    assert_eq!(event_topic, symbol_short!("upgrade"));
+    assert_eq!(event_wasm_hash, new_wasm_hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_upgrade_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+
+    // Mock only the non-admin authorization, admin should not be authorized
+    env.mock_all_auths_allowing_non_root_auth();
+
+    let new_wasm_hash = BytesN::from_array(&env, &[42u8; 32]);
+    // This should panic because non_admin is not the admin
+    client.upgrade(&new_wasm_hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_upgrade_before_init_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+    env.mock_all_auths();
+
+    let new_wasm_hash = BytesN::from_array(&env, &[42u8; 32]);
+    client.upgrade(&new_wasm_hash);
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -158,6 +158,59 @@ fn test_balance_of_and_count() {
 }
 
 #[test]
+fn test_revoke_wrap_increments_total_revoked() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[4u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 202401u64;
+    let signature = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period,
+        &archetype,
+        &hash,
+    );
+
+    client.mint_wrap(&user, &period, &archetype, &hash, &signature);
+    assert_eq!(client.total_revoked(), 0);
+
+    client.revoke_wrap(&user, &period);
+
+    assert_eq!(client.total_revoked(), 1);
+    assert_eq!(client.balance_of(&user), 0);
+    assert!(client.get_wrap(&user, &period).is_none());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_revoke_wrap_nonexistent_wrap_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    let user = Address::generate(&env);
+    client.revoke_wrap(&user, &202401);
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #1)")]
 fn test_initialize_twice_fails() {
     let env = Env::default();


### PR DESCRIPTION
Add total revoked counter and revoke_wrap query

Context:
Operators need a simple on-chain metric for how many records were revoked.

What changed:
- Added `DataKey::TotalRevoked` to storage_types.rs
- Added `ContractError::WrapNotFound` to errors.rs
- Implemented `admin::revoke_wrap` in admin.rs
  - requires admin auth
  - removes the wrap record
  - decrements the user’s `WrapCount`
  - increments global `TotalRevoked`
  - emits a `revoke` event
- Added `revoke_wrap` and `total_revoked` contract methods in lib.rs
- Added `queries::total_revoked` in queries.rs
- Added tests in test.rs for:
  - successful revoke increments global revoked counter
  - revoked wrap is removed and user balance updates
  - revoke of nonexistent wrap fails with `WrapNotFound`

Notes:
- `total_revoked` is stored in instance storage
- counter increments only on successful revocation
- Closes #283