### PR TITLE
refactor: extract mint signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,28 @@ Each wrap record stores:
 - `symbol(e: Env) -> String`
 - `decimals(e: Env) -> u32`
 
+## Security model
+
+Mint signatures are verified over a canonical payload that binds the request to:
+
+- a domain separator (`stellar-wrap-v1`)
+- the deploying contract instance address
+- the target user address
+- the period (`YYYYMM`)
+- the archetype symbol
+- the data hash
+
+The payload is constructed by concatenating the XDR-encoded fields in the order above. Off-chain signers should use the same byte layout when creating signatures:
+
+1. encode the domain separator as raw bytes
+2. append the XDR encoding of the contract address
+3. append the XDR encoding of the user address
+4. append the XDR encoding of the period as `u64`
+5. append the XDR encoding of the archetype symbol
+6. append the XDR encoding of the 32-byte data hash
+
+This ensures that a signature for one contract instance cannot be replayed against another deployment with the same admin key.
+
 ## Event schema
 
 Successful wrap mints emit one event:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod admin;
 mod errors;
 mod mint;
 mod queries;
+mod signature;
 mod storage_types;
 
 pub use errors::ContractError;

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -1,8 +1,6 @@
-use soroban_sdk::{
-    panic_with_error, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, Symbol,
-};
+use soroban_sdk::{panic_with_error, symbol_short, Address, BytesN, Env, Symbol};
 
-use crate::{ContractError, DataKey, WrapRecord};
+use crate::{signature::verify_mint_signature, ContractError, DataKey, WrapRecord};
 
 const TTL_ONE_YEAR: u32 = 17_280 * 365;
 
@@ -22,23 +20,6 @@ fn get_admin_pubkey(e: &Env) -> BytesN<32> {
         .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized))
 }
 
-fn build_payload(
-    e: &Env,
-    contract: &Address,
-    user: &Address,
-    period: u64,
-    archetype: &Symbol,
-    data_hash: &BytesN<32>,
-) -> Bytes {
-    let mut payload = Bytes::new(e);
-    payload.append(&contract.to_xdr(e));
-    payload.append(&user.clone().to_xdr(e));
-    payload.append(&period.to_xdr(e));
-    payload.append(&archetype.clone().to_xdr(e));
-    payload.append(&data_hash.clone().to_xdr(e));
-    payload
-}
-
 pub(crate) fn mint_wrap(
     e: Env,
     user: Address,
@@ -51,17 +32,16 @@ pub(crate) fn mint_wrap(
     validate_period(&e, period);
 
     let admin_pubkey = get_admin_pubkey(&e);
-    let payload = build_payload(
+    verify_mint_signature(
         &e,
+        &admin_pubkey,
         &e.current_contract_address(),
         &user,
         period,
         &archetype,
         &data_hash,
+        &signature,
     );
-
-    e.crypto()
-        .ed25519_verify(&admin_pubkey, &payload, &signature);
 
     let wrap_key = DataKey::Wrap(user.clone(), period);
     if e.storage().persistent().has(&wrap_key) {

--- a/src/security_test.rs
+++ b/src/security_test.rs
@@ -6,11 +6,11 @@
 //! cross-contract replay protection, and resource consumption.
 
 use super::*;
+use crate::signature::construct_mint_payload;
 use ed25519_dalek::{Signer, SigningKey};
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Ledger},
-    xdr::ToXdr,
     Address, Bytes, BytesN, Env, Symbol,
 };
 
@@ -24,12 +24,7 @@ fn sign_payload(
     archetype: &Symbol,
     data_hash: &BytesN<32>,
 ) -> BytesN<64> {
-    let mut payload = Bytes::new(env);
-    payload.append(&contract.to_xdr(env));
-    payload.append(&user.clone().to_xdr(env));
-    payload.append(&period.to_xdr(env));
-    payload.append(&archetype.clone().to_xdr(env));
-    payload.append(&data_hash.clone().to_xdr(env));
+    let payload = construct_mint_payload(env, contract, user, period, archetype, data_hash);
 
     let mut out = [0u8; 512];
     let len = payload.len() as usize;
@@ -282,7 +277,6 @@ fn test_signature_cannot_be_stolen_by_another_user() {
 fn test_cross_contract_replay_protection() {
     let env = Env::default();
 
-    // Deploy two separate contract instances (V1 and V2)
     let contract_v1 = env.register_contract(None, StellarWrapContract);
     let contract_v2 = env.register_contract(None, StellarWrapContract);
 
@@ -294,7 +288,6 @@ fn test_cross_contract_replay_protection() {
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
 
-    // Initialize both contracts with the same admin
     client_v1.initialize(&admin, &admin_pubkey);
     client_v2.initialize(&admin, &admin_pubkey);
 
@@ -302,7 +295,7 @@ fn test_cross_contract_replay_protection() {
 
     let data_hash = BytesN::from_array(&env, &[42u8; 32]);
     let archetype = symbol_short!("architect");
-    let period = 202512u64; // December 2025
+    let period = 202512u64;
 
     let signature_v1 = sign_payload(
         &env,
@@ -314,39 +307,26 @@ fn test_cross_contract_replay_protection() {
         &data_hash,
     );
 
-    // Mint successfully on V1
     client_v1.mint_wrap(&user, &period, &archetype, &data_hash, &signature_v1);
 
-    // Verify the wrap exists on V1
-    let wrap_v1 = client_v1.get_wrap(&user, &period);
-    assert!(wrap_v1.is_some(), "Wrap should exist on contract V1");
-
-    // The same user can mint on V2 (they are independent contracts)
-    // This should succeed because they are different contract instances
-    let signature_v2 = sign_payload(
-        &env,
-        &signing_key,
-        &contract_v2,
-        &user,
-        period,
-        &archetype,
-        &data_hash,
+    let payload_v1 =
+        construct_mint_payload(&env, &contract_v1, &user, period, &archetype, &data_hash);
+    let payload_v2 =
+        construct_mint_payload(&env, &contract_v2, &user, period, &archetype, &data_hash);
+    assert_ne!(
+        payload_v1, payload_v2,
+        "Payloads should differ across contract instances"
     );
 
-    client_v2.mint_wrap(&user, &period, &archetype, &data_hash, &signature_v2);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client_v2.mint_wrap(&user, &period, &archetype, &data_hash, &signature_v1);
+    }));
 
-    // Verify both contracts have independent storage
-    let wrap_v2 = client_v2.get_wrap(&user, &period);
-    assert!(wrap_v2.is_some(), "Wrap should exist on contract V2");
-
-    // Both wraps should exist independently
-    assert!(client_v1.get_wrap(&user, &period).is_some());
-    assert!(client_v2.get_wrap(&user, &period).is_some());
-
-    // NOTE: For full cross-contract replay protection, the signature
-    // verification should include the contract address in the signed payload.
-    // This test demonstrates that the contracts currently have independent storage,
-    // but additional signature binding to contract_id would prevent true replay attacks.
+    assert!(
+        result.is_err(),
+        "A signature from V1 should not be replayable on V2"
+    );
+    assert!(client_v2.get_wrap(&user, &period).is_none());
 }
 
 /// Test 6: Gas/Resource Analysis - CPU Instructions

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,0 +1,211 @@
+use soroban_sdk::{xdr::ToXdr, Address, Bytes, BytesN, Env, Symbol};
+
+use crate::ContractError;
+
+/// Domain separator used for mint signatures.
+///
+/// Off-chain signers must construct the same byte sequence before signing.
+/// Including a domain separator makes the payload self-describing and prevents
+/// ambiguity if the same key is reused for other Soroban contracts or future
+/// signing schemes.
+pub const MINT_DOMAIN_SEPARATOR: &[u8; 15] = b"stellar-wrap-v1";
+
+/// Construct the canonical mint payload that is signed by the admin.
+///
+/// The payload is the concatenation of a domain separator, the contract ID,
+/// the user address, the period, the archetype, and the data hash. Each field
+/// is encoded with XDR so the byte layout is deterministic and unambiguous.
+pub fn construct_mint_payload(
+    e: &Env,
+    contract_id: &Address,
+    user: &Address,
+    period: u64,
+    archetype: &Symbol,
+    data_hash: &BytesN<32>,
+) -> Bytes {
+    let mut payload = Bytes::new(e);
+    payload.append(&Bytes::from_array(e, MINT_DOMAIN_SEPARATOR));
+    payload.append(&contract_id.to_xdr(e));
+    payload.append(&user.clone().to_xdr(e));
+    payload.append(&period.to_xdr(e));
+    payload.append(&archetype.clone().to_xdr(e));
+    payload.append(&data_hash.clone().to_xdr(e));
+    payload
+}
+
+/// Verify an admin signature for a wrap mint request.
+///
+/// The verification is performed over the canonical mint payload so the
+/// signature is bound to the current contract instance, the target user,
+/// the period, the archetype, and the data hash.
+pub fn verify_mint_signature(
+    e: &Env,
+    admin_pubkey: &BytesN<32>,
+    contract_id: &Address,
+    user: &Address,
+    period: u64,
+    archetype: &Symbol,
+    data_hash: &BytesN<32>,
+    signature: &BytesN<64>,
+) -> Result<(), ContractError> {
+    let payload = construct_mint_payload(e, contract_id, user, period, archetype, data_hash);
+    e.crypto().ed25519_verify(admin_pubkey, &payload, signature);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Bytes, BytesN, Env, Symbol};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    use crate::StellarWrapContract;
+
+    fn sign_payload(
+        env: &Env,
+        signer: &SigningKey,
+        contract: &Address,
+        user: &Address,
+        period: u64,
+        archetype: &Symbol,
+        data_hash: &BytesN<32>,
+    ) -> BytesN<64> {
+        let payload = construct_mint_payload(env, contract, user, period, archetype, data_hash);
+
+        let mut out = [0u8; 512];
+        let len = payload.len() as usize;
+        payload.copy_into_slice(&mut out[..len]);
+
+        let signature = signer.sign(&out[..len]);
+        BytesN::from_array(env, &signature.to_bytes())
+    }
+
+    #[test]
+    fn test_construct_mint_payload_has_expected_byte_layout() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let user = Address::generate(&env);
+        let archetype = symbol_short!("arch");
+        let data_hash = BytesN::from_array(&env, &[42u8; 32]);
+        let period = 202512u64;
+
+        let payload =
+            construct_mint_payload(&env, &contract_id, &user, period, &archetype, &data_hash);
+
+        let mut expected = Bytes::new(&env);
+        expected.append(&Bytes::from_array(&env, MINT_DOMAIN_SEPARATOR));
+        expected.append(&contract_id.to_xdr(&env));
+        expected.append(&user.clone().to_xdr(&env));
+        expected.append(&period.to_xdr(&env));
+        expected.append(&archetype.clone().to_xdr(&env));
+        expected.append(&data_hash.clone().to_xdr(&env));
+
+        assert_eq!(payload, expected);
+    }
+
+    #[test]
+    fn test_verify_mint_signature_accepts_valid_signature() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let user = Address::generate(&env);
+        let archetype = symbol_short!("arch");
+        let data_hash = BytesN::from_array(&env, &[7u8; 32]);
+        let period = 202601u64;
+
+        let signing_key = SigningKey::from_bytes(&[11u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let signature = sign_payload(
+            &env,
+            &signing_key,
+            &contract_id,
+            &user,
+            period,
+            &archetype,
+            &data_hash,
+        );
+
+        assert!(verify_mint_signature(
+            &env,
+            &admin_pubkey,
+            &contract_id,
+            &user,
+            period,
+            &archetype,
+            &data_hash,
+            &signature,
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_verify_mint_signature_rejects_invalid_signature() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let user = Address::generate(&env);
+        let archetype = symbol_short!("arch");
+        let data_hash = BytesN::from_array(&env, &[8u8; 32]);
+        let period = 202602u64;
+
+        let signing_key = SigningKey::from_bytes(&[12u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let invalid_signature = BytesN::from_array(&env, &[0u8; 64]);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            verify_mint_signature(
+                &env,
+                &admin_pubkey,
+                &contract_id,
+                &user,
+                period,
+                &archetype,
+                &data_hash,
+                &invalid_signature,
+            )
+            .unwrap();
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_mint_signature_rejects_wrong_key() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let user = Address::generate(&env);
+        let archetype = symbol_short!("arch");
+        let data_hash = BytesN::from_array(&env, &[9u8; 32]);
+        let period = 202603u64;
+
+        let signing_key = SigningKey::from_bytes(&[13u8; 32]);
+        let wrong_signing_key = SigningKey::from_bytes(&[14u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let wrong_signature = sign_payload(
+            &env,
+            &wrong_signing_key,
+            &contract_id,
+            &user,
+            period,
+            &archetype,
+            &data_hash,
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            verify_mint_signature(
+                &env,
+                &admin_pubkey,
+                &contract_id,
+                &user,
+                period,
+                &archetype,
+                &data_hash,
+                &wrong_signature,
+            )
+            .unwrap();
+        }));
+
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
 Summary
This PR extracts the mint signature verification flow into a reusable module to improve separation of concerns and make the signature logic directly testable.

 
closes #122
closes #125