### PR TITLE
ci(#273): align clippy command with CONTRIBUTING pre-push hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Check format
       run: cargo fmt --check
     - name: Run clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --all-targets -- -D warnings
     - name: Run tests
       run: cargo test
 


### PR DESCRIPTION
CONTRIBUTING.md pre-push hook runs:
  cargo clippy --all-targets -- -D warnings

CI was running:
  cargo clippy -- -D warnings  (missing --all-targets)

Update the 'Run clippy' step to add --all-targets so CI and the local pre-push hook exercise the same set of targets (lib, tests, examples, benches), catching issues in test-only code that the old command missed.

Closes #273