### PR TITLE
feat(#288): add user-controlled profile alias hash

### DIFF
--- a/src/alias.rs
+++ b/src/alias.rs
@@ -1,0 +1,25 @@
+use soroban_sdk::{Address, BytesN, Env};
+
+use crate::DataKey;
+
+const TTL_ONE_YEAR: u32 = 17_280 * 365;
+
+/// Store a 32-byte alias hash for the calling user.
+///
+/// `require_auth` is called so only the user themselves can set or update
+/// their alias hash — no admin involvement required.
+pub(crate) fn set_alias_hash(e: Env, user: Address, alias_hash: BytesN<32>) {
+    user.require_auth();
+    let key = DataKey::AliasHash(user);
+    e.storage().persistent().set(&key, &alias_hash);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_ONE_YEAR, TTL_ONE_YEAR);
+}
+
+/// Return the alias hash for `user`, or `None` if not set.
+pub(crate) fn get_alias_hash(e: Env, user: Address) -> Option<BytesN<32>> {
+    e.storage()
+        .persistent()
+        .get(&DataKey::AliasHash(user))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, Symbol};
 
 mod admin;
+mod alias;
 mod errors;
 mod mint;
 mod queries;
@@ -53,6 +54,20 @@ impl StellarWrapContract {
 
     pub fn get_admin(e: Env) -> Option<Address> {
         queries::get_admin(e)
+    }
+
+    /// Set or update the caller's alias hash.
+    ///
+    /// Only the `user` themselves can call this — `require_auth` is enforced
+    /// inside the alias module. The hash is stored as opaque 32-byte data so
+    /// no raw personal information ever touches the chain.
+    pub fn set_alias_hash(e: Env, user: Address, alias_hash: BytesN<32>) {
+        alias::set_alias_hash(e, user, alias_hash);
+    }
+
+    /// Return the alias hash for `user`, or `None` if one has not been set.
+    pub fn get_alias_hash(e: Env, user: Address) -> Option<BytesN<32>> {
+        alias::get_alias_hash(e, user)
     }
 
     pub fn name(e: Env) -> String {

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -10,7 +10,7 @@ fn validate_period(e: &Env, period: u64) {
     let year = period / 100;
     let month = period % 100;
 
-    if year < 2024 || year > 2100 || month < 1 || month > 12 {
+    if !(2024..=2100).contains(&year) || !(1..=12).contains(&month) {
         panic_with_error!(e, ContractError::InvalidPeriod);
     }
 }

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -22,4 +22,6 @@ pub enum DataKey {
     WrapCount(Address),
     /// Stores the latest period minted for a specific user.
     LatestPeriod(Address),
+    /// Stores a user-controlled 32-byte alias hash for privacy-preserving profile display.
+    AliasHash(Address),
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -662,3 +662,104 @@ fn test_get_admin_before_init_returns_none() {
 
     assert!(client.get_admin().is_none());
 }
+
+// ---------------------------------------------------------------------------
+// Alias hash tests (#288)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_set_and_get_alias_hash() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    client.initialize(&admin, &pubkey);
+
+    let user = Address::generate(&env);
+    let alias_hash = BytesN::from_array(&env, &[0xabu8; 32]);
+
+    // No hash set yet
+    assert!(client.get_alias_hash(&user).is_none());
+
+    env.mock_all_auths();
+    client.set_alias_hash(&user, &alias_hash);
+
+    assert_eq!(client.get_alias_hash(&user).unwrap(), alias_hash);
+}
+
+#[test]
+fn test_update_alias_hash() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[2u8; 32]);
+    client.initialize(&admin, &pubkey);
+
+    let user = Address::generate(&env);
+    let hash_v1 = BytesN::from_array(&env, &[0x11u8; 32]);
+    let hash_v2 = BytesN::from_array(&env, &[0x22u8; 32]);
+
+    env.mock_all_auths();
+    client.set_alias_hash(&user, &hash_v1);
+    assert_eq!(client.get_alias_hash(&user).unwrap(), hash_v1);
+
+    // Overwrite with a new hash
+    client.set_alias_hash(&user, &hash_v2);
+    assert_eq!(client.get_alias_hash(&user).unwrap(), hash_v2);
+}
+
+#[test]
+fn test_alias_hash_is_per_user() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[3u8; 32]);
+    client.initialize(&admin, &pubkey);
+
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let hash_a = BytesN::from_array(&env, &[0xaau8; 32]);
+    let hash_b = BytesN::from_array(&env, &[0xbbu8; 32]);
+
+    env.mock_all_auths();
+    client.set_alias_hash(&user_a, &hash_a);
+    client.set_alias_hash(&user_b, &hash_b);
+
+    assert_eq!(client.get_alias_hash(&user_a).unwrap(), hash_a);
+    assert_eq!(client.get_alias_hash(&user_b).unwrap(), hash_b);
+    // Ensure they are distinct
+    assert_ne!(
+        client.get_alias_hash(&user_a).unwrap(),
+        client.get_alias_hash(&user_b).unwrap()
+    );
+}
+
+#[test]
+fn test_get_alias_hash_returns_none_for_unknown_user() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let unknown_user = Address::generate(&env);
+    assert!(client.get_alias_hash(&unknown_user).is_none());
+}
+
+#[test]
+#[should_panic]
+fn test_set_alias_hash_requires_auth() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    // Do NOT call env.mock_all_auths() — auth must be required
+    let user = Address::generate(&env);
+    let alias_hash = BytesN::from_array(&env, &[0xccu8; 32]);
+
+    client.set_alias_hash(&user, &alias_hash);
+}


### PR DESCRIPTION
- Add AliasHash(Address) variant to DataKey enum
- Implement src/alias.rs with set_alias_hash / get_alias_hash
- Wire both methods into StellarWrapContract in lib.rs
- set_alias_hash enforces require_auth so only the owner can write
- Stores a fixed-length BytesN<32> — no raw personal data on chain
- Extend persistent TTL (1 year) on every write
- Add 5 tests: set, update, per-user isolation, None for unknown user, and auth-required guard (panic without mock_all_auths)
- Also fix pre-existing clippy::manual_range_contains in mint.rs

Closes #288