### PR TITLE
Asserted that failed mints do not update LatestPeriod

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@ impl StellarWrapContract {
 }
 
 #[cfg(test)]
+mod prop_test;
+#[cfg(test)]
 mod security_test;
 #[cfg(test)]
 mod test;

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -32,10 +32,10 @@ fn build_payload(
 ) -> Bytes {
     let mut payload = Bytes::new(e);
     payload.append(&contract.to_xdr(e));
-    payload.append(&user.clone().to_xdr(e));
+    payload.append(&user.to_xdr(e));
     payload.append(&period.to_xdr(e));
-    payload.append(&archetype.clone().to_xdr(e));
-    payload.append(&data_hash.clone().to_xdr(e));
+    payload.append(&archetype.to_xdr(e));
+    payload.append(&data_hash.to_xdr(e));
     payload
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -39,6 +39,66 @@ fn sign_payload(
 }
 
 #[test]
+fn test_failed_mint_does_not_update_latest_period() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[14u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    let archetype = symbol_short!("arch");
+    let hash = BytesN::from_array(&env, &[42u8; 32]);
+    
+    let period_1: u64 = 202401;
+    let signature_1 = sign_payload(
+        &env,
+        &signing_key,
+        &contract_id,
+        &user,
+        period_1,
+        &archetype,
+        &hash,
+    );
+    client.mint_wrap(&user, &period_1, &archetype, &hash, &signature_1); 
+
+    let latest_wrap = client.get_latest_wrap(&user).unwrap();
+    assert_eq!(latest_wrap.period, period_1, "Latest wrap should be period_1 after successful mint");
+
+    let period_2: u64 = 202402;
+    
+    let bad_signing_key = SigningKey::from_bytes(&[99u8; 32]);
+    let invalid_signature = sign_payload(
+        &env,
+        &bad_signing_key,
+        &contract_id,
+        &user,
+        period_2,
+        &archetype,
+        &hash,
+    );
+    
+    let failed_mint_result = client.try_mint_wrap(&user, &period_2, &archetype, &hash, &invalid_signature);
+    
+    assert!(
+        failed_mint_result.is_err(), 
+        "Mint should fail for invalid signature"
+    );
+
+    let latest_wrap_after_fail = client.get_latest_wrap(&user).unwrap();
+    assert_eq!(
+        latest_wrap_after_fail.period, 
+        period_1, 
+        "LatestPeriod should only change after successful mint storage commits"
+    );
+}
+
+#[test]
 fn test_minting_flow() {
     let env = Env::default();
     let contract_id = env.register_contract(None, StellarWrapContract);


### PR DESCRIPTION
Closes #237 

- Added prop test mod to `lib.rs`
- Removed redundant `.clone()` from `mint.rs`
- Added `test_failed_mint_does_not_update_latest_period`