### PR TITLE
docs: add local development quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,63 @@ Recommended aggregation rule:
 3. count events per user
 4. sort descending by count to produce the leaderboard
 
-## Development
+## Local Development Quickstart
 
-Run the test suite with:
+### Prerequisites
 
+- **Rust** – install via [rustup](https://rustup.rs/). The project targets a recent stable toolchain.
+- **wasm32 target** – add the WebAssembly compilation target:
+  ```bash
+  rustup target add wasm32-unknown-unknown
+  ```
+- **Stellar CLI** (recommended) – install from the [Stellar soroban-cli releases](https://github.com/stellar/stellar-cli/releases) or via `cargo`:
+  ```bash
+  cargo install stellar-cli
+  ```
+  Alternatively, install the legacy **Soroban CLI**:
+  ```bash
+  cargo install soroban-cli
+  ```
+
+### Common commands
+
+| Action | Command |
+|---|---|
+| Format | `cargo fmt` |
+| Format check (CI) | `cargo fmt --check` or `make fmt-check` |
+| Lint | `cargo clippy -- -D warnings` or `make lint` |
+| Test | `cargo test` or `make test` |
+| Release build (WASM) | `cargo build --release --target wasm32-unknown-unknown` or `make build` |
+| Deploy to testnet | `make deploy-testnet` |
+| Docker reproducible build | `make docker-build` or `docker build -t stellar-wrap-contract .` |
+
+See the `Makefile` for the full list of targets (`make help`).
+
+### Troubleshooting
+
+**"target `wasm32-unknown-unknown` not installed"**
 ```bash
-cargo test
+rustup target add wasm32-unknown-unknown
 ```
+
+**SDK / toolchain mismatch errors** (e.g. `package \`soroban-sdk\` cannot be built because it requires a different Rust version`)
+
+The Soroban SDK often tracks Rust nightly or a specific stable release. If you see version conflicts:
+- Verify your Rust version matches what the lockfile expects:
+  ```bash
+  rustup show
+  rustup update stable
+  ```
+- If the SDK pins a nightly, install and use it:
+  ```bash
+  rustup install nightly-YYYY-MM-DD
+  rustup target add wasm32-unknown-unknown --toolchain nightly-YYYY-MM-DD
+  cargo +nightly-YYYY-MM-DD build --release --target wasm32-unknown-unknown
+  ```
+- Clean stale artifacts before switching toolchains:
+  ```bash
+  cargo clean
+  ```
+
+**WASM build fails with link errors**
+Ensure `wasm32-unknown-unknown` is the active target and no host-specific native dependencies leak in. The `Dockerfile` provides a fully isolated environment for reproducible WASM builds.


### PR DESCRIPTION
Covers prerequisites (Rust, wasm target, Stellar/Soroban CLI), all key commands (fmt, clippy, test, release build), and troubleshooting for wasm target and SDK/toolchain mismatches.

**Closes #227** 