### PR TITLE
feat(#263): add signed payload domain separator

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,1 +1,4 @@
-
+/// Domain separator string prepended to every signed mint payload.
+/// Binds all signatures to this specific protocol version so that
+/// future protocol changes cannot accidentally reuse old signatures.
+pub const DOMAIN_SEPARATOR: &str = "StellarWrap-v1";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, Symbol};
 
 mod admin;
+mod constants;
 mod errors;
 mod mint;
 mod queries;

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{
-    panic_with_error, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, Symbol,
+    panic_with_error, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Symbol,
 };
 
 use crate::{ContractError, DataKey, WrapRecord};
@@ -31,6 +31,9 @@ fn build_payload(
     data_hash: &BytesN<32>,
 ) -> Bytes {
     let mut payload = Bytes::new(e);
+    // Domain separator binds signatures to this protocol version,
+    // preventing replay across protocol upgrades.
+    payload.append(&String::from_str(e, crate::constants::DOMAIN_SEPARATOR).to_xdr(e));
     payload.append(&contract.to_xdr(e));
     payload.append(&user.clone().to_xdr(e));
     payload.append(&period.to_xdr(e));

--- a/src/prop_test.rs
+++ b/src/prop_test.rs
@@ -7,10 +7,11 @@ use super::*;
 
 use ed25519_dalek::{Signer, SigningKey};
 use proptest::prelude::*;
+use crate::constants::DOMAIN_SEPARATOR;
 use soroban_sdk::{
     testutils::Address as _,
     xdr::ToXdr,
-    Address, Bytes, BytesN, Env, Symbol,
+    Address, Bytes, BytesN, Env, String, Symbol,
 };
 
 // ── Shared test constants ────────────────────────────────────────────────────
@@ -70,6 +71,8 @@ fn sign_mint(
     data_hash: &BytesN<32>,
 ) -> BytesN<64> {
     let mut payload = Bytes::new(env);
+    // Domain separator binds signatures to this protocol version
+    payload.append(&String::from_str(env, DOMAIN_SEPARATOR).to_xdr(env));
     payload.append(&contract.to_xdr(env));
     payload.append(&user.clone().to_xdr(env));
     payload.append(&period.to_xdr(env));

--- a/src/security_test.rs
+++ b/src/security_test.rs
@@ -7,11 +7,12 @@
 
 use super::*;
 use ed25519_dalek::{Signer, SigningKey};
+use crate::constants::DOMAIN_SEPARATOR;
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Ledger},
     xdr::ToXdr,
-    Address, Bytes, BytesN, Env, Symbol,
+    Address, Bytes, BytesN, Env, String, Symbol,
 };
 
 /// Helper function to sign payloads for testing
@@ -25,6 +26,8 @@ fn sign_payload(
     data_hash: &BytesN<32>,
 ) -> BytesN<64> {
     let mut payload = Bytes::new(env);
+    // Domain separator binds signatures to this protocol version
+    payload.append(&String::from_str(env, DOMAIN_SEPARATOR).to_xdr(env));
     payload.append(&contract.to_xdr(env));
     payload.append(&user.clone().to_xdr(env));
     payload.append(&period.to_xdr(env));

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,6 +4,7 @@ extern crate std;
 
 use super::*;
 use ed25519_dalek::{Signer, SigningKey};
+use crate::constants::DOMAIN_SEPARATOR;
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events},
@@ -24,6 +25,8 @@ fn sign_payload(
     data_hash: &BytesN<32>,
 ) -> BytesN<64> {
     let mut payload = Bytes::new(env);
+    // Domain separator must be prepended to bind signatures to this protocol version
+    payload.append(&String::from_str(env, DOMAIN_SEPARATOR).to_xdr(env));
     payload.append(&contract.to_xdr(env));
     payload.append(&user.clone().to_xdr(env));
     payload.append(&period.to_xdr(env));
@@ -661,4 +664,45 @@ fn test_get_admin_before_init_returns_none() {
     let client = StellarWrapContractClient::new(&env, &contract_id);
 
     assert!(client.get_admin().is_none());
+}
+
+/// Negative test: old-domain signatures (without domain separator) must be rejected.
+/// This proves domain separation protects against replay across protocol upgrades.
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_old_domain_signature_rejected() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let signing_key = SigningKey::from_bytes(&[99u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &admin_pubkey);
+    env.mock_all_auths();
+
+    // Build a signature using the OLD payload format (no domain separator)
+    // This simulates a signature from a previous protocol version
+    let dummy_hash = BytesN::from_array(&env, &[42u8; 32]);
+    let archetype = symbol_short!("arch");
+    let period = 202401u64;
+
+    let mut old_payload = Bytes::new(&env);
+    old_payload.append(&contract_id.to_xdr(&env));
+    old_payload.append(&user.clone().to_xdr(&env));
+    old_payload.append(&period.to_xdr(&env));
+    old_payload.append(&archetype.clone().to_xdr(&env));
+    old_payload.append(&dummy_hash.clone().to_xdr(&env));
+
+    let mut out = [0u8; 512];
+    let len = old_payload.len() as usize;
+    old_payload.copy_into_slice(&mut out[..len]);
+    let sig = signing_key.sign(&out[..len]);
+    let old_signature = BytesN::from_array(&env, &sig.to_bytes());
+
+    // This should panic with InvalidSignature (#5) because the payload
+    // doesn't include the domain separator
+    client.mint_wrap(&user, &period, &archetype, &dummy_hash, &old_signature);
 }


### PR DESCRIPTION
Closes #263

---

## Summary

Adds a stable domain separator (`StellarWrap-v1`) prepended to every signed mint payload to bind signatures to this specific protocol version, preventing replay attacks across protocol upgrades.

## Changes

- **`src/constants.rs`**: Added `DOMAIN_SEPARATOR` constant (`"StellarWrap-v1"`)
- **`src/lib.rs`**: Added `mod constants;` declaration
- **`src/mint.rs`**: Updated `build_payload()` to prepend the domain separator before all other fields
- **`src/test.rs`**: Updated `sign_payload()` helper to include domain separator; added `test_old_domain_signature_rejected` negative test proving old-domain signatures fail with `Error(Contract, #5)`
- **`src/security_test.rs`**: Updated `sign_payload()` helper to include domain separator
- **`src/prop_test.rs`**: Updated `sign_mint()` helper to include domain separator

## Testing

- `cargo check` passes (all source compiles)
- All signing helpers across all test files updated to include domain separator
- Added negative test verifying old-format signatures are rejected