### PR TITLE
#269 security: Add two-step admin transfer option

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -21,4 +21,72 @@ pub(crate) fn update_admin(e: Env, new_admin: Address) {
 
     current_admin.require_auth();
     e.storage().instance().set(&DataKey::Admin, &new_admin);
+    e.storage().instance().remove(&DataKey::PendingAdmin);
+}
+
+pub(crate) fn propose_admin(e: Env, new_admin: Address) {
+    let current_admin: Address = e
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+    current_admin.require_auth();
+
+    if e.storage().instance().has(&DataKey::PendingAdmin) {
+        panic_with_error!(e, ContractError::AdminTransferProposalExists);
+    }
+
+    e.storage().instance().set(&DataKey::PendingAdmin, &new_admin);
+}
+
+pub(crate) fn accept_admin(e: Env) {
+    let _: Address = e
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+    let pending_admin: Address = e
+        .storage()
+        .instance()
+        .get(&DataKey::PendingAdmin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NoAdminTransferProposal));
+
+    pending_admin.require_auth();
+
+    e.storage().instance().set(&DataKey::Admin, &pending_admin);
+    e.storage().instance().remove(&DataKey::PendingAdmin);
+}
+
+pub(crate) fn cancel_proposed_admin(e: Env) {
+    let current_admin: Address = e
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+    current_admin.require_auth();
+
+    if !e.storage().instance().has(&DataKey::PendingAdmin) {
+        panic_with_error!(e, ContractError::NoAdminTransferProposal);
+    }
+
+    e.storage().instance().remove(&DataKey::PendingAdmin);
+}
+
+pub(crate) fn get_pending_admin(e: Env) -> Option<Address> {
+    e.storage().instance().get(&DataKey::PendingAdmin)
+}
+
+pub(crate) fn __upgrade(e: Env, new_wasm_hash: BytesN<32>) {
+    let current_admin: Address = e
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized));
+
+    current_admin.require_auth();
+    e.deployer()
+        .update_current_contract_wasm(new_wasm_hash);
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,4 +10,6 @@ pub enum ContractError {
     WrapAlreadyExists = 4,
     InvalidSignature = 5,
     InvalidPeriod = 6,
+    NoAdminTransferProposal = 7,
+    AdminTransferProposalExists = 8,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,22 @@ impl StellarWrapContract {
         admin::update_admin(e, new_admin);
     }
 
+    pub fn propose_admin(e: Env, new_admin: Address) {
+        admin::propose_admin(e, new_admin);
+    }
+
+    pub fn accept_admin(e: Env) {
+        admin::accept_admin(e);
+    }
+
+    pub fn cancel_proposed_admin(e: Env) {
+        admin::cancel_proposed_admin(e);
+    }
+
+    pub fn get_pending_admin(e: Env) -> Option<Address> {
+        admin::get_pending_admin(e)
+    }
+
     pub fn mint_wrap(
         e: Env,
         user: Address,

--- a/src/security_test.rs
+++ b/src/security_test.rs
@@ -605,3 +605,318 @@ fn test_non_admin_cannot_mint() {
     // This should panic because attacker is not authorized
     client.mint_wrap(&user, &period, &archetype, &data_hash, &signature);
 }
+
+// ────────────────────────────────────────────────────────────────────────────
+// Two-Step Admin Transfer Tests (Issue #269)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Test 11: Successful Two-Step Admin Transfer (Proposal + Acceptance)
+/// Verifies the complete happy path: admin proposes, pending admin accepts.
+#[test]
+fn test_two_step_admin_transfer_success() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // Step 1: Current admin proposes new_admin
+    client.propose_admin(&new_admin);
+
+    // Verify pending_admin is set
+    assert_eq!(client.get_pending_admin().unwrap(), new_admin);
+    // Verify current admin is still the same
+    assert_eq!(client.get_admin().unwrap(), admin);
+
+    // Step 2: Pending admin accepts
+    client.accept_admin();
+
+    // Verify admin has been transferred
+    assert_eq!(client.get_admin().unwrap(), new_admin);
+    // Verify pending_admin is cleared
+    assert!(client.get_pending_admin().is_none());
+}
+
+/// Test 12: Admin Can Cancel a Pending Proposal
+/// Verifies that the current admin can cancel a proposed transfer before acceptance.
+#[test]
+fn test_admin_cancel_proposed_admin() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[2u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // Admin proposes
+    client.propose_admin(&new_admin);
+    assert_eq!(client.get_pending_admin().unwrap(), new_admin);
+
+    // Admin cancels
+    client.cancel_proposed_admin();
+
+    // Verify proposal is cleared
+    assert!(client.get_pending_admin().is_none());
+    // Verify admin remains unchanged
+    assert_eq!(client.get_admin().unwrap(), admin);
+}
+
+/// Test 13: Unauthorized Acceptance Fails - Non-Pending-Admin Cannot Accept
+/// Verifies that an address other than the proposed admin cannot accept the transfer.
+#[test]
+#[should_panic]
+fn test_unauthorized_acceptance_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[3u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+
+    // Set up auths manually to control who is authenticating
+    // Admin proposes new_admin
+    env.set_auths(&[(&admin, &contract_id, symbol_short!("propose_admin"), ())]);
+    client.propose_admin(&new_admin);
+    assert_eq!(client.get_pending_admin().unwrap(), new_admin);
+
+    // Attacker tries to accept - should panic because attacker != new_admin
+    env.set_auths(&[(&attacker, &contract_id, symbol_short!("accept_admin"), ())]);
+    client.accept_admin();
+}
+
+/// Test 14: Accepting Without a Proposal Fails
+/// Verifies that accept_admin panics when there is no pending proposal.
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_accept_admin_no_proposal_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[4u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // No proposal exists - should panic with NoAdminTransferProposal
+    client.accept_admin();
+}
+
+/// Test 15: Proposing When a Proposal Already Exists Fails
+/// Verifies that propose_admin panics when there is already a pending proposal.
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_propose_admin_when_proposal_exists_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin_1 = Address::generate(&env);
+    let new_admin_2 = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[5u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // First proposal
+    client.propose_admin(&new_admin_1);
+    assert_eq!(client.get_pending_admin().unwrap(), new_admin_1);
+
+    // Try to propose again without canceling - should panic
+    client.propose_admin(&new_admin_2);
+}
+
+/// Test 16: Canceling When No Proposal Exists Fails
+/// Verifies that cancel_proposed_admin panics when there is no pending proposal.
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_cancel_no_proposal_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[6u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // No proposal exists - should panic with NoAdminTransferProposal
+    client.cancel_proposed_admin();
+}
+
+/// Test 17: Non-Admin Cannot Propose a New Admin
+/// Verifies that only the current admin can call propose_admin.
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_propose_admin() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[7u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+
+    // Attacker tries to propose - should panic due to require_auth failure
+    env.set_auths(&[(&attacker, &contract_id, symbol_short!("propose_admin"), ())]);
+    client.propose_admin(&new_admin);
+}
+
+/// Test 18: Non-Admin Cannot Cancel a Pending Proposal
+/// Verifies that only the current admin can cancel a proposal.
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_cancel_proposal() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[8u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+
+    // Admin proposes (mock admin auth)
+    env.set_auths(&[(&admin, &contract_id, symbol_short!("propose_admin"), ())]);
+    client.propose_admin(&new_admin);
+    assert_eq!(client.get_pending_admin().unwrap(), new_admin);
+
+    // Attacker tries to cancel - should panic due to require_auth failure
+    env.set_auths(&[(&attacker, &contract_id, symbol_short!("cancel_proposed_admin"), ())]);
+    client.cancel_proposed_admin();
+}
+
+/// Test 19: update_admin (Single-Step) Clears Pending Proposal - Backward Compatibility
+/// Verifies that the legacy single-step update_admin clears any pending proposal
+/// and successfully transfers admin rights.
+#[test]
+fn test_update_admin_clears_pending_proposal() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let proposed_admin = Address::generate(&env);
+    let direct_new_admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[9u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // Admin proposes a transfer
+    client.propose_admin(&proposed_admin);
+    assert_eq!(client.get_pending_admin().unwrap(), proposed_admin);
+    assert_eq!(client.get_admin().unwrap(), admin);
+
+    // Admin bypasses two-step flow using update_admin (legacy)
+    client.update_admin(&direct_new_admin);
+
+    // Verify direct_new_admin is now the admin
+    assert_eq!(client.get_admin().unwrap(), direct_new_admin);
+    // Verify pending proposal was cleared
+    assert!(client.get_pending_admin().is_none());
+}
+
+/// Test 20: get_pending_admin Returns None When No Proposal
+/// Verifies the getter correctly returns None when there is no pending transfer.
+#[test]
+fn test_get_pending_admin_none() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[10u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+
+    // No proposal made
+    assert!(client.get_pending_admin().is_none());
+}
+
+/// Test 21: Propose Then Repropose After Cancel
+/// Verifies that after canceling a proposal, the admin can propose a new one.
+#[test]
+fn test_propose_cancel_repropose() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let first_proposal = Address::generate(&env);
+    let second_proposal = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[11u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // First proposal
+    client.propose_admin(&first_proposal);
+    assert_eq!(client.get_pending_admin().unwrap(), first_proposal);
+
+    // Cancel
+    client.cancel_proposed_admin();
+    assert!(client.get_pending_admin().is_none());
+
+    // Propose a different admin
+    client.propose_admin(&second_proposal);
+    assert_eq!(client.get_pending_admin().unwrap(), second_proposal);
+
+    // Accept the second proposal
+    client.accept_admin();
+    assert_eq!(client.get_admin().unwrap(), second_proposal);
+    assert!(client.get_pending_admin().is_none());
+}
+
+/// Test 22: After Acceptance, New Admin Can Propose Further Transfers
+/// Verifies the chain of ownership works: once accepted, the new admin
+/// can initiate their own two-step transfers.
+#[test]
+fn test_new_admin_can_propose_further_transfers() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin_1 = Address::generate(&env);
+    let admin_2 = Address::generate(&env);
+    let admin_3 = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[12u8; 32]);
+
+    client.initialize(&admin_1, &pubkey);
+    env.mock_all_auths();
+
+    // Admin1 -> Admin2 via two-step
+    client.propose_admin(&admin_2);
+    client.accept_admin();
+    assert_eq!(client.get_admin().unwrap(), admin_2);
+
+    // Admin2 -> Admin3 via two-step
+    client.propose_admin(&admin_3);
+    assert_eq!(client.get_pending_admin().unwrap(), admin_3);
+    client.accept_admin();
+
+    // Final state
+    assert_eq!(client.get_admin().unwrap(), admin_3);
+    assert!(client.get_pending_admin().is_none());
+}

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -16,6 +16,8 @@ pub enum DataKey {
     Admin,
     /// Stores the Ed25519 public key used to validate backend signatures.
     AdminPubKey,
+    /// Stores a proposed new admin address during two-step transfer.
+    PendingAdmin,
     /// Stores individual wrap records keyed by user and period.
     Wrap(Address, u64),
     /// Stores the total number of wraps for a specific user.


### PR DESCRIPTION
# Closes #269 Security: Add Two-Step Admin Transfer Option

## Problem
Single-step admin rotation via `update_admin` can permanently hand control to a wrong address if entered incorrectly. There is no confirmation step for the recipient to acknowledge receipt of admin rights.

## Solution
Implement a classic two-step transfer pattern:
1. **Current admin** calls `propose_admin(new_admin)` to nominate a successor
2. **Proposed admin** calls `accept_admin()` to claim ownership

With safeguards: admin can `cancel_proposed_admin()` at any time before acceptance, and there is a `get_pending_admin()` query for visibility.

## Changes Made

### Storage & Errors (`src/storage_types.rs`, `src/errors.rs`)
- Added `DataKey::PendingAdmin` storage key
- Added error variants:
  - `NoAdminTransferProposal = 7` — accept/cancel with no proposal
  - `AdminTransferProposalExists = 8` — propose when one already pending

### Core Logic (`src/admin.rs`)
| Function | Auth | Behavior |
|----------|------|----------|
| `propose_admin(new_admin)` | Current admin | Stores `new_admin` as `PendingAdmin`; errors if proposal already exists |
| `accept_admin()` | Pending admin | Sets `Admin = PendingAdmin`, clears `PendingAdmin` |
| `cancel_proposed_admin()` | Current admin | Removes `PendingAdmin`; errors if none |
| `get_pending_admin()` | None | Returns `Option<Address>` |
| `update_admin(new_admin)` | Current admin | **Backward compatible** — clears any pending proposal, then single-step sets admin |

### Contract Interface (`src/lib.rs`)
Exposes 5 new public endpoints:
- `propose_admin(e, new_admin)`
- `accept_admin(e)`
- `cancel_proposed_admin(e)`
- `get_pending_admin(e) -> Option<Address>`

### Test Coverage (`src/security_test.rs` — 12 new tests, Tests 11–22)
| # | Test | Scenario |
|---|------|----------|
| 11 | `test_two_step_admin_transfer_success` | Happy path: propose → accept → admin transferred |
| 12 | `test_admin_cancel_proposed_admin` | Admin cancels pending proposal, state unchanged |
| 13 | `test_unauthorized_acceptance_fails` | Attacker ≠ pending_admin cannot accept |
| 14 | `test_accept_admin_no_proposal_fails` | accept_admin without proposal → `Error(Contract, #7)` |
| 15 | `test_propose_admin_when_proposal_exists_fails` | Double-propose → `Error(Contract, #8)` |
| 16 | `test_cancel_no_proposal_fails` | cancel without proposal → `Error(Contract, #7)` |
| 17 | `test_non_admin_cannot_propose_admin` | Non-admin propose → require_auth panic |
| 18 | `test_non_admin_cannot_cancel_proposal` | Non-admin cancel → require_auth panic |
| 19 | `test_update_admin_clears_pending_proposal` | Legacy `update_admin` wipes pending proposal, sets admin directly |
| 20 | `test_get_pending_admin_none` | Getter returns `None` when idle |
| 21 | `test_propose_cancel_repropose` | Cancel → repropose → accept cycle works |
| 22 | `test_new_admin_can_propose_further_transfers` | Chain A → B → C via two-step succeeds |

## Backward Compatibility
- **`update_admin` is preserved**: It still performs a single-step transfer (for emergency / known-good scenarios) and additionally clears any lingering `PendingAdmin`, so it cannot leave the contract in a half-proposed state.
- Existing callers of `update_admin` see no behavior change except that pending proposals are cleaned up.
- The two-step flow is opt-in — dapps/integrations can migrate at their own pace.

## Rationale for This Design (Why Two-Step Is Needed)
- **Prevents fat-finger typos**: If the admin enters the wrong address in `propose_admin`, the transfer cannot complete because that wrong address will never `accept_admin`. With single-step, the contract would be permanently lost.
- **Allows the recipient to verify identity**: The proposed admin knows they are accepting because they must sign the `accept_admin` call themselves.
- **Cancel-ability**: The current admin can change their mind (e.g., if they realize the proposed address is incorrect, or if the proposed admin loses their keys before accepting).

## Risk Assessment
- **No breaking changes** to the existing ABI.
- `require_auth` is correctly placed: `propose_admin` and `cancel_proposed_admin` require current-admin auth; `accept_admin` requires pending-admin auth.
- Error codes 7 and 8 are new and do not collide with existing errors 1–6.