### PR TITLE
(docs): Add CLI examples for read-only contract queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,66 @@ Each wrap record stores:
 - `symbol(e: Env) -> String`
 - `decimals(e: Env) -> u32`
 
+### CLI examples
+
+Placeholder variables:
+
+- `<CONTRACT_ID>` — deployed contract address (e.g. `C...`)
+- `<USER_ADDRESS>` — Stellar account address (e.g. `G...`)
+- `<PERIOD>` — period encoded as `YYYYMM` (e.g. `202401`)
+- `<DATA_HEX>` — hex-encoded raw data bytes
+
+#### `get_wrap`
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  -- \
+  get_wrap \
+  --user <USER_ADDRESS> \
+  --period <PERIOD>
+```
+
+Returns `Option<WrapRecord>` — either the record (see [WrapRecord](#wraprecord)) or `null`.
+
+#### `get_latest_wrap`
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  -- \
+  get_latest_wrap \
+  --user <USER_ADDRESS>
+```
+
+Returns `Option<WrapRecord>` — same shape as `get_wrap`, or `null`.
+
+#### `balance_of`
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  -- \
+  balance_of \
+  --user <USER_ADDRESS>
+```
+
+Returns an integer count of wraps for the user (e.g. `42`).
+
+#### `verify_data`
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  -- \
+  verify_data \
+  --user <USER_ADDRESS> \
+  --period <PERIOD> \
+  --data <DATA_HEX>
+```
+
+Returns `true` if `sha256(data)` matches the stored `data_hash`, otherwise `false`.
+
 ## Event schema
 
 Successful wrap mints emit one event:


### PR DESCRIPTION
## docs: Add CLI examples for read-only contract queries

Added a new `### CLI examples` section under `## Public interface` in `README.md` 
with `soroban contract invoke` examples for all four read-only query functions.

**Changes:**

- `README.md` — inserted a CLI examples subsection covering:

| Function | Args | Output |
|---|---|---|
| `get_wrap` | `user`, `period` | `Option<WrapRecord>` |
| `get_latest_wrap` | `user` | `Option<WrapRecord>` |
| `balance_of` | `user` | `i128` |
| `verify_data` | `user`, `period`, `data` | `bool` |

Each example uses placeholder variables (`<CONTRACT_ID>`, `<USER_ADDRESS>`, 
`<PERIOD>`, `<DATA_HEX>`) and describes the expected return shape.

Closes #215