### PR TITLE
ci: add cargo doc check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       run: cargo fmt --check
     - name: Run clippy
       run: cargo clippy -- -D warnings
+    - name: Check doc compilation
+      run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
     - name: Run tests
       run: cargo test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@
 * **Clean Commits:** Use descriptive commit messages (e.g., `feat: implement mint function` not `fix`).
 * **No Force Pushing:** If you need to change something, add a new commit or squash locally before pushing.
 * **Code Style:** Ensure `cargo fmt` and `cargo clippy` pass before submitting.
+* **Doc Check:** Run `make doc` (or `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`) to verify documentation compiles without warnings.
 
 **Step 2.1: Install Git Hooks (Required)**
 1. Install pre-commit once on your machine:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test fmt fmt-check lint clean deploy-testnet wasm-build docker-build docker-build-verify
+.PHONY: build test fmt fmt-check lint doc clean deploy-testnet wasm-build docker-build docker-build-verify
 
 # ── Build ────────────────────────────────────────────────────────────────────
 
@@ -38,6 +38,10 @@ fmt-check:
 ## lint: Run clippy and treat all warnings as errors
 lint:
 	cargo clippy -- -D warnings
+
+## doc: Build contract documentation and treat warnings as errors
+doc:
+	RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
 
 # ── Deploy ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Adds `cargo doc --no-deps` to CI to ensure public contract documentation compiles cleanly as the codebase grows.

## Changes
- Added `cargo doc --no-deps` step to CI workflow (`.github/workflows/ci.yml`)
- Added `make doc` target to `Makefile`
- Documented how to run the doc check locally in `CONTRIBUTING.md`

Closes #306