### PR TITLE
refactor: add crate-level module documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,17 @@
+//! # Stellar Wrap Registry
+//!
+//! A Soroban smart contract on Stellar that records timestamped data-wrap
+//! commitments on-chain. Each wrap binds a user address, a period
+//! (`YYYYMM`), an archetype label, and a SHA-256 data hash into an
+//! immutable record.
+//!
+//! ## Security
+//!
+//! Minting requires an Ed25519 signature from the configured admin key
+//! over the full payload (contract ID, user, period, archetype, data hash).
+//! This prevents unauthorized wraps even if the caller contract is
+//! compromised. The admin address controls the public-key rotation.
+
 #![no_std]
 
 use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, Symbol};


### PR DESCRIPTION
## Summary

Adds crate-level documentation to `src/lib.rs` describing the Stellar Wrap Registry and its security-critical signing behavior.

## Changes
- Added `//!` inner doc comments at the crate root describing the registry's purpose and Ed25519 signing security model

Closes #303