### PR TITLE
feat: verify data hashes through oracle contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Returned by `health()`, reports:
 - `initialized: bool` — whether `initialize()` has been called
 - `has_admin: bool` — whether an admin address is currently configured
 - `has_signing_key: bool` — whether an admin signing key is currently configured
->>>>>>> main
 
 ## Storage keys
 
@@ -69,6 +68,7 @@ Returned by `health()`, reports:
 - `get_wrap(e: Env, user: Address, period: u64) -> Option<WrapRecord>`
 - `balance_of(e: Env, user: Address) -> i128`
 - `verify_data(e: Env, user: Address, period: u64, data: Bytes) -> bool`
+- `verify_with_oracle(e: Env, oracle: Address, data_hash: BytesN<32>) -> bool`
 - `get_latest_wrap(e: Env, user: Address) -> Option<WrapRecord>`
 - `get_admin(e: Env) -> Option<Address>`
 - `health(e: Env) -> ContractHealth`
@@ -76,6 +76,25 @@ Returned by `health()`, reports:
 - `symbol(e: Env) -> String`
 - `decimals(e: Env) -> u32`
 - `migration_version(e: Env) -> u32`
+
+## Oracle hash verification
+
+`verify_with_oracle` performs a read-only cross-contract call to the supplied
+oracle address. A compatible oracle exposes this ABI:
+
+```text
+verify_data_hash(data_hash: BytesN<32>) -> bool
+```
+
+The hash is forwarded unchanged. The oracle returns `true` when its
+decentralized verification process recognizes the hash and `false` when it
+does not. Contract invocation failures, a missing method, and incompatible
+return values propagate as call errors; they are never converted to `false`.
+
+The caller supplies the oracle address, so a `true` response is only as
+trustworthy as that selected oracle. Applications should use a vetted oracle
+contract ID from their own configuration. This method does not mutate wrap
+records and does not replace the local `verify_data` comparison.
 
 ## Event schemas
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,29 +8,16 @@ use soroban_sdk::{contract, contractimpl, Address, Bytes, BytesN, Env, String, S
 mod admin;
 mod errors;
 mod mint;
+mod oracle;
 mod queries;
 mod storage_types;
 
 pub use errors::ContractError;
+pub use oracle::DataHashOracle;
 pub use storage_types::{ContractHealth, DataKey, WrapRecord};
 
 #[contract]
 pub struct StellarWrapContract;
-use soroban_sdk::{
-    contracterror,
-    panic_with_error,
-    symbol_short,
-    Address, BytesN, Env, Symbol,
-};
-
-/// Errors returned by the StellarWrap contract.
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum ContractError {
-    /// A wrap record for this `(user, period)` pair already exists. (code 4)
-    WrapAlreadyExists = 4,
-}
 
 #[contractimpl]
 impl StellarWrapContract {
@@ -61,17 +48,6 @@ impl StellarWrapContract {
         signature: BytesN<64>,
     ) {
         mint::mint_wrap(e, user, period, archetype, data_hash, signature);
-        let key = (user.clone(), period);
-        if e.storage().persistent().has(&key) {
-            panic_with_error!(e, ContractError::WrapAlreadyExists);
-        }
-        let record = WrapRecord {
-            timestamp: e.ledger().timestamp(),
-            data_hash,
-            archetype,
-            period,
-        };
-        e.storage().persistent().set(&key, &record);
     }
 
     pub fn get_wrap(e: Env, user: Address, period: u64) -> Option<WrapRecord> {
@@ -91,6 +67,14 @@ impl StellarWrapContract {
 
     pub fn verify_data(e: Env, user: Address, period: u64, data: Bytes) -> bool {
         queries::verify_data(e, user, period, data)
+    }
+
+    /// Asks an external oracle contract whether `data_hash` is recognized.
+    ///
+    /// The oracle must expose `verify_data_hash(BytesN<32>) -> bool`.
+    /// Oracle invocation and ABI errors propagate to the caller.
+    pub fn verify_with_oracle(e: Env, oracle: Address, data_hash: BytesN<32>) -> bool {
+        oracle::verify_data_hash(&e, &oracle, &data_hash)
     }
 
     pub fn get_latest_wrap(e: Env, user: Address) -> Option<WrapRecord> {
@@ -118,6 +102,8 @@ impl StellarWrapContract {
     }
 }
 
+#[cfg(test)]
+mod oracle_test;
 #[cfg(test)]
 mod security_test;
 #[cfg(test)]

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -1,0 +1,11 @@
+use soroban_sdk::{contractclient, Address, BytesN, Env};
+
+/// Minimal ABI implemented by a compatible data-hash oracle.
+#[contractclient(name = "DataHashOracleClient")]
+pub trait DataHashOracle {
+    fn verify_data_hash(e: Env, data_hash: BytesN<32>) -> bool;
+}
+
+pub(crate) fn verify_data_hash(e: &Env, oracle: &Address, data_hash: &BytesN<32>) -> bool {
+    DataHashOracleClient::new(e, oracle).verify_data_hash(data_hash)
+}

--- a/src/oracle_test.rs
+++ b/src/oracle_test.rs
@@ -1,0 +1,128 @@
+use super::{StellarWrapContract, StellarWrapContractClient};
+use soroban_sdk::{contract, contractimpl, testutils::Address as _, Address, BytesN, Env};
+
+const APPROVED_HASH: [u8; 32] = [7; 32];
+
+mod mock_oracle {
+    use super::*;
+
+    #[contract]
+    pub struct MockOracle;
+
+    #[contractimpl]
+    impl MockOracle {
+        pub fn verify_data_hash(e: Env, data_hash: BytesN<32>) -> bool {
+            data_hash == BytesN::from_array(&e, &APPROVED_HASH)
+        }
+    }
+}
+
+mod failing_oracle {
+    use super::*;
+
+    #[contract]
+    pub struct FailingOracle;
+
+    #[contractimpl]
+    impl FailingOracle {
+        pub fn verify_data_hash(_e: Env, _data_hash: BytesN<32>) -> bool {
+            panic!("oracle unavailable")
+        }
+    }
+}
+
+mod wrong_abi_oracle {
+    use super::*;
+
+    #[contract]
+    pub struct WrongAbiOracle;
+
+    #[contractimpl]
+    impl WrongAbiOracle {
+        pub fn verify_data_hash(_e: Env, _data_hash: BytesN<32>) -> u32 {
+            1
+        }
+    }
+}
+
+mod missing_method_oracle {
+    use super::*;
+
+    #[contract]
+    pub struct MissingMethodOracle;
+
+    #[contractimpl]
+    impl MissingMethodOracle {
+        pub fn ping(_e: Env) -> bool {
+            true
+        }
+    }
+}
+
+#[test]
+fn oracle_accepts_recognized_hash() {
+    let env = Env::default();
+    let wrap_id = env.register_contract(None, StellarWrapContract);
+    let oracle_id = env.register_contract(None, mock_oracle::MockOracle);
+    let wrap = StellarWrapContractClient::new(&env, &wrap_id);
+    let data_hash = BytesN::from_array(&env, &APPROVED_HASH);
+
+    assert!(wrap.verify_with_oracle(&oracle_id, &data_hash));
+}
+
+#[test]
+fn oracle_rejection_is_returned() {
+    let env = Env::default();
+    let wrap_id = env.register_contract(None, StellarWrapContract);
+    let oracle_id = env.register_contract(None, mock_oracle::MockOracle);
+    let wrap = StellarWrapContractClient::new(&env, &wrap_id);
+    let unknown_hash = BytesN::from_array(&env, &[8; 32]);
+
+    assert!(!wrap.verify_with_oracle(&oracle_id, &unknown_hash));
+}
+
+#[test]
+fn oracle_failure_is_not_treated_as_rejection() {
+    let env = Env::default();
+    let wrap_id = env.register_contract(None, StellarWrapContract);
+    let oracle_id = env.register_contract(None, failing_oracle::FailingOracle);
+    let wrap = StellarWrapContractClient::new(&env, &wrap_id);
+    let data_hash = BytesN::from_array(&env, &APPROVED_HASH);
+
+    assert!(wrap.try_verify_with_oracle(&oracle_id, &data_hash).is_err());
+}
+
+#[test]
+fn non_contract_oracle_address_fails() {
+    let env = Env::default();
+    let wrap_id = env.register_contract(None, StellarWrapContract);
+    let non_contract = Address::generate(&env);
+    let wrap = StellarWrapContractClient::new(&env, &wrap_id);
+    let data_hash = BytesN::from_array(&env, &APPROVED_HASH);
+
+    assert!(wrap
+        .try_verify_with_oracle(&non_contract, &data_hash)
+        .is_err());
+}
+
+#[test]
+fn incompatible_oracle_return_type_fails() {
+    let env = Env::default();
+    let wrap_id = env.register_contract(None, StellarWrapContract);
+    let oracle_id = env.register_contract(None, wrong_abi_oracle::WrongAbiOracle);
+    let wrap = StellarWrapContractClient::new(&env, &wrap_id);
+    let data_hash = BytesN::from_array(&env, &APPROVED_HASH);
+
+    assert!(wrap.try_verify_with_oracle(&oracle_id, &data_hash).is_err());
+}
+
+#[test]
+fn missing_oracle_method_fails() {
+    let env = Env::default();
+    let wrap_id = env.register_contract(None, StellarWrapContract);
+    let oracle_id = env.register_contract(None, missing_method_oracle::MissingMethodOracle);
+    let wrap = StellarWrapContractClient::new(&env, &wrap_id);
+    let data_hash = BytesN::from_array(&env, &APPROVED_HASH);
+
+    assert!(wrap.try_verify_with_oracle(&oracle_id, &data_hash).is_err());
+}

--- a/src/security_test.rs
+++ b/src/security_test.rs
@@ -14,7 +14,6 @@ use soroban_sdk::{
     Address, BytesN, Env,
 };
 
-
 /// Test 1: Replay Attack Simulation
 /// Ensures that a valid signature cannot be reused for the same period
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -14,7 +14,6 @@ use std::vec::Vec;
 
 const STRESS_USER_COUNT: usize = 128;
 
-
 #[test]
 fn test_minting_flow() {
     let env = Env::default();
@@ -667,7 +666,6 @@ fn test_get_admin_before_init_returns_none() {
 
 #[test]
 fn test_migrate_applies_once_per_version() {
-fn test_get_mint_timestamp_exists() {
     let env = Env::default();
     let contract_id = env.register_contract(None, StellarWrapContract);
     let client = StellarWrapContractClient::new(&env, &contract_id);
@@ -690,6 +688,26 @@ fn test_get_mint_timestamp_exists() {
 #[test]
 #[should_panic(expected = "Error(Contract, #7)")]
 fn test_migrate_rejects_replay() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.migrate(&1);
+    client.migrate(&1);
+}
+
+#[test]
+fn test_get_mint_timestamp_exists() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
     let signing_key = SigningKey::from_bytes(&[14u8; 32]);
     let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
     let admin = Address::generate(&env);
@@ -726,14 +744,10 @@ fn test_get_mint_timestamp_missing() {
     let contract_id = env.register_contract(None, StellarWrapContract);
     let client = StellarWrapContractClient::new(&env, &contract_id);
 
-    let admin = Address::generate(&env);
-    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+    let period = 202401u64;
 
-    client.initialize(&admin, &pubkey);
-    env.mock_all_auths();
-
-    client.migrate(&1);
-    client.migrate(&1);
+    assert_eq!(client.get_mint_timestamp(&user, &period), None);
 }
 
 #[test]
@@ -745,8 +759,4 @@ fn test_migrate_before_init_fails() {
     env.mock_all_auths();
 
     client.migrate(&1);
-    let user = Address::generate(&env);
-    let period = 202401u64;
-
-    assert_eq!(client.get_mint_timestamp(&user, &period), None);
 }

--- a/test_snapshots/test/test_initialize_twice_fails.1.json
+++ b/test_snapshots/test/test_initialize_twice_fails.1.json
@@ -63,49 +63,6 @@
                         "val": {
                           "bytes": "0101010101010101010101010101010101010101010101010101010101010101"
                         }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "AllowedArchetypes"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "vec": [
-                            {
-                              "symbol": "builder"
-                            },
-                            {
-                              "symbol": "arch"
-                            },
-                            {
-                              "symbol": "architect"
-                            },
-                            {
-                              "symbol": "soroban"
-                            },
-                            {
-                              "symbol": "defi"
-                            },
-                            {
-                              "symbol": "patron"
-                            }
-                          ]
-                        }
-                      },
-                      {
-                        "key": {
-                          "vec": [
-                            {
-                              "symbol": "SchemaVersion"
-                            }
-                          ]
-                        },
-                        "val": {
-                          "u32": 3
-                        }
                       }
                     ]
                   }


### PR DESCRIPTION
## Summary

- add a typed Soroban client for decentralized data-hash oracle contracts
- expose a read-only `verify_with_oracle` entrypoint and propagate oracle/ABI failures
- cover approvals, rejections, missing methods, invalid addresses, failures, and incompatible return types
- repair pre-existing merge artifacts that prevented the contract from compiling

## Verification

- `cargo test --locked` — 43 passed
- `cargo fmt -- --check` — passed
- release `wasm32-unknown-unknown` build — passed (14 KB)
- `git diff --check` — passed

Fixes #527