### PR TITLE
[Refactor] Extract standard token interface into TokenInterface trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,11 @@ mod queries;
 mod revoke;
 mod signature;
 mod storage_types;
+mod token;
 
 pub use errors::ContractError;
 pub use storage_types::{ContractHealth, DataKey, WrapLifecycleFSM, WrapRecord, WrapState};
+pub use token::TokenInterface;
 
 #[contract]
 pub struct StellarWrapContract;
@@ -124,10 +126,6 @@ impl StellarWrapContract {
     /// Returns `None` if no mint has occurred for the given user-period.
     pub fn get_mint_timestamp(e: Env, user: Address, period: u64) -> Option<u64> {
         queries::get_mint_timestamp(e, user, period)
-    }
-
-    pub fn balance_of(e: Env, user: Address) -> i128 {
-        queries::balance_of(e, user)
     }
 
     pub fn total_wrap_count(e: Env) -> u32 {
@@ -266,24 +264,34 @@ impl StellarWrapContract {
         alias::get_alias_hash(e, user)
     }
 
-    pub fn name(e: Env) -> String {
-        queries::name(e)
-    }
-
-    pub fn symbol(e: Env) -> String {
-        queries::symbol(e)
-    }
-
-    pub fn decimals(e: Env) -> u32 {
-        queries::decimals(e)
-    }
-
     pub fn revoke_wrap(e: Env, user: Address, period: u64, reason_hash: BytesN<32>) {
         revoke::revoke_wrap(e, user, period, reason_hash);
     }
 
     pub fn total_revoked(e: Env) -> u64 {
         queries::total_revoked(e)
+    }
+}
+
+/// Token interface implementation — generated as contract functions via
+/// `#[contractimpl]` so clients can call `name`, `symbol`, `decimals`,
+/// and `balance_of` directly.
+#[contractimpl]
+impl token::TokenInterface for StellarWrapContract {
+    fn name(e: Env) -> String {
+        queries::name(e)
+    }
+
+    fn symbol(e: Env) -> String {
+        queries::symbol(e)
+    }
+
+    fn decimals(e: Env) -> u32 {
+        queries::decimals(e)
+    }
+
+    fn balance_of(e: Env, user: Address) -> i128 {
+        queries::balance_of(e, user)
     }
 }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,38 @@
+//! Standard token interface trait for the Stellar Wrap Registry.
+//!
+//! Extracts the standard token interface methods (`name`, `symbol`, `decimals`,
+//! `balance_of`) into a dedicated trait, reducing boilerplate in `lib.rs` and
+//! promoting interface reuse.
+//!
+//! The trait is implemented directly in `lib.rs` with `#[contractimpl]` so
+//! the Soroban macro generates client types in the correct crate scope.
+//!
+//! # Standard Interface Methods
+//!
+//! | Method       | Description                         |
+//! |--------------|-------------------------------------|
+//! | `name`       | Token display name (default: "Stellar Wrap Registry") |
+//! | `symbol`     | Token ticker symbol (default: "WRAP") |
+//! | `decimals`   | Number of decimals (always 0 for soulbound wraps) |
+//! | `balance_of` | Number of active wraps for a user   |
+
+use soroban_sdk::{Address, Env, String};
+
+/// Standard token interface trait for `StellarWrapContract`.
+///
+/// Implemented in `lib.rs` via `#[contractimpl]` so these methods are
+/// automatically exposed as contract functions. The implementations
+/// delegate to the `queries` module for storage access.
+pub trait TokenInterface {
+    /// Returns the token name, either the admin-set override or the default.
+    fn name(e: Env) -> String;
+
+    /// Returns the token symbol, either the admin-set override or the default.
+    fn symbol(e: Env) -> String;
+
+    /// Returns the number of decimals (always 0 for this contract).
+    fn decimals(e: Env) -> u32;
+
+    /// Returns the number of active wrap records for the given user.
+    fn balance_of(e: Env, user: Address) -> i128;
+}


### PR DESCRIPTION
Extract the standard token interface methods (name, symbol, decimals, balance_of) from the main #[contractimpl] block into a dedicated TokenInterface trait defined in src/token.rs.

Closes #466