### PR TITLE
docs: refresh security recommendations and add upgrade runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,27 +384,216 @@ stellar contract read \
   --period 202401
 ```
 
-### Upgrading an existing contract
+## 💿 Upgrade runbook
 
-To upgrade an existing contract instead of deploying fresh:
+This runbook covers the end-to-end process of upgrading a deployed contract to
+a new WASM version: building, uploading, capturing the WASM hash, invoking the
+admin-authorized upgrade, and validating the result.
+
+### How it works
+
+Upgrading a Soroban contract replaces its executable code while **preserving all
+storage** (wrap records, admin config, migration state, etc.). No data is lost
+during the upgrade.
+
+The contract exposes an `upgrade(new_wasm_hash)` function that:
+1. Verifies the contract has been initialized (`NotInitialized` otherwise).
+2. Requires authorization from the **admin address** (`Unauthorized` otherwise).
+3. Emits an `upgrade` audit event containing the requested WASM hash.
+4. Calls `e.deployer().update_current_contract_wasm(new_wasm_hash)` to replace
+   the code.
+
+The upgrade function is defined in `src/admin.rs`. The contract code is
+implemented in `src/lib.rs`.
+
+> **Storage is preserved.** Any changes to the storage layout must be shipped as
+> a numbered migration via `migrate(version)` — see the [Upgrade compatibility]
+> section below.
+
+### Prerequisites
+
+- **Stellar CLI** (`stellar`) — [installation guide](https://developers.stellar.org/docs/soroban/install)
+- **Admin secret key** for the deployed contract (the same address passed as
+  `admin` to `initialize()`)
+- **Deployer account** with XLM to cover the upload and invocation fees
+- The upgrade runbook assumes **testnet**; for mainnet replace
+  `--network testnet` with `--network mainnet` throughout.
+
+### Step 1 — Build the new WASM
 
 ```bash
+make build
+# or: cargo build --release --target wasm32-unknown-unknown
+```
+
+The WASM artifact is at:
+`target/wasm32-unknown-unknown/release/stellar_wrap_contract.wasm`
+
+> **Reproducible builds:** Always build against the committed `Cargo.lock`
+> (`cargo build --locked`) to ensure the WASM hash matches across environments.
+> The Dockerfile provides a fully isolated build:
+> ```bash
+> make docker-build
+> ```
+
+### Step 2 — Upload the WASM and capture the hash
+
+Upload the new WASM to the network. The CLI returns the **WASM hash** (a 32-byte
+hex-encoded SHA-256 of the WASM blob):
+
+```bash
+stellar contract upload \
+  --wasm target/wasm32-unknown-unknown/release/stellar_wrap_contract.wasm \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY>
+```
+
+**Save the returned WASM hash.** It will be passed as `new_wasm_hash` to the
+`upgrade()` function in the next step.
+
+Alternatively, using the Makefile:
+
+```bash
+export STELLAR_DEPLOYER_SECRET="S..."   # or the admin secret
 export CONTRACT_ID="<EXISTING_CONTRACT_ID>"
 make deploy-testnet
 ```
 
-This will upload the new WASM without creating a new contract instance.
-## Upgrade compatibility
+The Makefile target prints the WASM hash to stdout. Capture it from the output.
+
+### Step 3 — Invoke the upgrade
+
+Call the contract's `upgrade` function with the captured WASM hash:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY> \
+  -- \
+  upgrade \
+  --new_wasm_hash <WASM_HASH_HEX>
+```
+
+**Authorization:** The `--source` account must match the admin address stored in
+the contract. If it does not, the invocation panics with `Unauthorized` (code 3).
+
+**Failure mode — wrong WASM hash:** If the hash does not correspond to a WASM
+blob previously uploaded on the same network, Soroban rejects the upgrade with
+a host error. The contract state is **not modified** — storage remains intact.
+
+### Step 4 — Verify the upgrade
+
+#### Smoke check 1 — Confirm health
+
+The health endpoint should still report the contract as initialized:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY> \
+  -- \
+  health
+```
+
+Expected output:
+```json
+{"initialized": true, "has_admin": true, "has_signing_key": true}
+```
+
+#### Smoke check 2 — Verify storage is preserved
+
+Existing wrap records must be readable after the upgrade:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  -- \
+  get_wrap \
+  --user <USER_ADDRESS> \
+  --period <PERIOD>
+```
+
+If records existed before the upgrade, they should still be returned. If no
+records exist (fresh contract), this returns `null`.
+
+#### Smoke check 3 — Run migrations (if needed)
+
+If the new code introduces a storage migration, call `migrate` immediately
+after the upgrade, in the same transaction batch if possible:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  --source <ADMIN_SECRET_KEY> \
+  -- \
+  migrate \
+  --version <NEXT_VERSION>
+```
+
+Verify the migration was applied:
+
+```bash
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  -- \
+  migration_version
+```
+
+Expected output: `NEXT_VERSION` (or whatever version was passed to `migrate`).
+
+> If `migrate` is called twice with the same version, it panics with
+> `MigrationAlreadyApplied` (code 7) — see [ERRORS.md](./ERRORS.md).
+
+#### Smoke check 4 — Mint a test wrap
+
+Mint a new wrap to confirm the upgraded code handles write operations correctly:
+
+```bash
+# Follow the minting instructions in the testnet deployment walkthrough above
+```
+
+### Failure modes
+
+| Symptom | Likely cause | Resolution |
+|---------|-------------|------------|
+| `Error(Contract, #2)` — `NotInitialized` | Contract has not been `initialize()`'d | Call `initialize(admin, admin_pubkey)` first |
+| `Error(Contract, #3)` — `Unauthorized` | `--source` is not the admin address | Use the correct admin secret key |
+| `HostError: ...wasm hash...` | WASM hash does not match any uploaded blob | Re-upload the WASM and verify the hash |
+| `Error(Contract, #7)` — `MigrationAlreadyApplied` | `migrate` called twice with same version | Check `migration_version()` first; this is not a real error |
+| Contract behaves the same as before | Storage is preserved — expected behavior. Check the event log for the `upgrade` audit event | Confirm the upgrade event was emitted: `stellar contract event --id <CONTRACT_ID>` |
+| Unexpected storage behaviour | The new code changed a `DataKey` variant or record shape without a migration | Add a migration step and re-upgrade |
+
+### Upgrade compatibility
 
 An upgrade replaces contract code while keeping storage, so any change to the
 storage layout must ship as a numbered migration:
 
 - `DataKey::MigrationVersion` stores the highest migration version applied (`0` before any migration).
 - `migrate(version)` is admin-only and only accepts a version greater than the stored one, so a
-  migration can never run twice — a replay panics with `MigrationAlreadyApplied` (#7).
+  migration can never run twice — a replay panics with `MigrationAlreadyApplied` (code 7).
 - Additive changes (new `DataKey` variants, new methods) need no migration; changing or removing
   the shape of an existing key does, and the new code must bump the migration version.
 - Call `migrate` in the same transaction batch as the upgrade, and verify with `migration_version()`.
+
+### Key security considerations
+
+1. **The upgrade function is admin-only.** If the admin keypair is compromised,
+   an attacker can replace the contract WASM. Consider a time-lock or multi-sig
+   admin for production deployments.
+2. **Storage is never wiped.** Sensitive data stored by a previous version
+   remains accessible after upgrade. Ensure the new code handles all existing
+   `DataKey` variants gracefully.
+3. **Audit trail.** Every upgrade emits an `upgrade` event with the new WASM
+   hash. Indexers and monitoring tools should watch for unexpected upgrade
+   events. The event topic is `upgrade` with data being the new WASM hash.
+4. **Rollback.** To revert an upgrade, build and upload the previous WASM, then
+   invoke `upgrade` with the old WASM hash. Storage is preserved across
+   rollbacks as well.
 ## Documentation
 
 - [Canonical signed payload encoding](docs/signing-payload.md) — exact field order, XDR encoding rules, and test vectors required by backend signing services (issue #213)

--- a/SECURITY_RECOMMENDATIONS.md
+++ b/SECURITY_RECOMMENDATIONS.md
@@ -12,9 +12,9 @@ For developer-facing error handling (e.g. `Error(Contract, #4)`), see the
 ## ✅ Signature Verification — Implemented (Ed25519)
 
 ### Current State
-`mint_wrap()` and `update_wrap()` perform real Ed25519 cryptographic signature
-verification using Soroban's built-in `e.crypto().ed25519_verify()`. The old
-unconditional stub (`fn verify_signature() -> bool { true }`) no longer exists.
+All mint operations perform real Ed25519 cryptographic signature verification
+using Soroban's built-in `e.crypto().ed25519_verify()`. Verification is
+implemented in `src/signature.rs` via the `verify_mint_signature()` function.
 
 ### How It Works
 
@@ -25,31 +25,66 @@ against the stored admin public key before minting.
 #### Payload construction (`mint_wrap`)
 
 ```
-payload = 0x01
-        ‖ XDR(contract_address)
-        ‖ XDR(user)
-        ‖ XDR(period)        // u64 — prevents period replay
+payload = b"stellar-wrap-v1"                   // domain separator (15 bytes)
+        ‖ XDR(payload_version: u32)             // currently 1
+        ‖ XDR(contract_address)                 // cross-contract replay protection
+        ‖ XDR(user)                             // identity binding
+        ‖ XDR(period)                           // u64 — prevents period replay
         ‖ XDR(archetype)
-        ‖ XDR(data_hash)     // SHA-256 of off-chain JSON
+        ‖ XDR(data_hash)                        // SHA-256 of off-chain JSON
 ```
 
-The first byte is a payload version field. The contract currently accepts version `1` only, and backend signers must use this version for all new signatures.
+The domain separator (`b"stellar-wrap-v1"`) makes the payload self-describing and
+prevents ambiguity if the same Ed25519 key is reused across contracts or signing
+schemes. A `payload_version` field follows the domain separator; the contract
+currently accepts version `1` only, and backend signers must use this version for
+all new signatures.
 
 Each field is XDR-encoded before concatenation, which provides unambiguous
 length-delimited framing and prevents field-boundary collisions.
 
 #### On-chain verification (Rust)
 
-```rust
-let mut payload = Bytes::new(&e);
-payload.append(&e.current_contract_address().to_xdr(&e));   // cross-contract replay protection
-payload.append(&user.clone().to_xdr(&e));                   // identity binding
-payload.append(&period.to_xdr(&e));                         // period binding
-payload.append(&archetype.clone().to_xdr(&e));
-payload.append(&data_hash.clone().to_xdr(&e));
+The actual verification lives in `src/signature.rs`:
 
-// Panics with ContractError::InvalidSignature (code 6) on failure
-e.crypto().ed25519_verify(&admin_pubkey, &payload, &signature);
+```rust
+pub fn verify_mint_signature(
+    e: &Env,
+    admin_pubkey: &BytesN<32>,
+    contract_id: &Address,
+    user: &Address,
+    period: u64,
+    archetype: &Symbol,
+    data_hash: &BytesN<32>,
+    payload_version: u32,
+    signature: &BytesN<64>,
+) -> Result<(), ContractError> {
+    let payload = construct_mint_payload(
+        e, contract_id, user, period, archetype, data_hash, payload_version,
+    );
+    e.crypto().ed25519_verify(admin_pubkey, &payload, signature);
+    Ok(())
+}
+
+fn construct_mint_payload(
+    e: &Env,
+    contract_id: &Address,
+    user: &Address,
+    period: u64,
+    archetype: &Symbol,
+    data_hash: &BytesN<32>,
+    payload_version: u32,
+) -> Bytes {
+    let mut payload = Bytes::new(e);
+    payload.append(&Bytes::from_array(e, MINT_DOMAIN_SEPARATOR));
+    payload.append(&payload_version.to_xdr(e));
+    payload.append(&contract_id.to_xdr(e));
+    payload.append(&user.clone().to_xdr(e));
+    payload.append(&period.to_xdr(e));
+    payload.append(&archetype.clone().to_xdr(e));
+    payload.append(&data_hash.clone().to_xdr(e));
+    payload
+}
 ```
 
 `ed25519_verify` panics (traps) when verification fails — the transaction is
@@ -61,14 +96,19 @@ rolled back and no state is written.
 import { xdr, Address } from "@stellar/stellar-sdk";
 import * as nacl from "tweetnacl";
 
+const MINT_DOMAIN_SEPARATOR = Buffer.from("stellar-wrap-v1", "utf-8");
+
 function buildMintPayload(
   contractId: string,
   userAddress: string,
   period: bigint,
   archetype: string,
-  dataHash: Uint8Array
+  dataHash: Uint8Array,
+  payloadVersion: number = 1,
 ): Uint8Array {
   const parts: Uint8Array[] = [
+    MINT_DOMAIN_SEPARATOR,
+    xdr.Uint64.fromBigInt(BigInt(payloadVersion)).toXDR(),
     xdr.ScAddress.scAddressTypeContract(Buffer.from(contractId, "hex")).toXDR(),
     Address.fromString(userAddress).toXDR(),
     xdr.Uint64.fromBigInt(period).toXDR(),
@@ -78,9 +118,9 @@ function buildMintPayload(
   return Buffer.concat(parts);
 }
 
-const payload  = buildMintPayload(contractId, user, period, archetype, dataHash);
+const payload  = buildMintPayload(contractId, user, period, archetype, dataHash, 1);
 const signature = nacl.sign.detached(payload, adminSecretKey);
-// Pass signature (64 bytes) as the `signature` argument to mint_wrap()
+// Pass signature (64 bytes) alongside payload_version=1 to mint_wrap()
 ```
 
 ### Security Properties Provided
@@ -88,7 +128,7 @@ const signature = nacl.sign.detached(payload, adminSecretKey);
 | Property | How it is enforced |
 |---|---|
 | **Identity binding** | `user` is in the payload; a signature for Alice cannot be used by Bob |
-| **Cross-contract replay** | `contract_address` is the first payload field |
+| **Cross-contract replay** | `contract_address` is included in the payload; a signature for contract V1 cannot be replayed against V2 |
 | **Period replay** | `period` is in the payload; same user cannot reuse a signature for a different period |
 | **Data integrity** | `data_hash` (SHA-256 of JSON) is in the payload and also stored on-chain |
 | **Duplicate prevention** | `WrapAlreadyExists` check after signature verification |
@@ -257,15 +297,16 @@ cross-version replay attack.
 
 This contract defends against this by:
 
-1. Prepending `payload_version: u32` as the **first** element of every signed
-   payload.
+1. Prepending a **domain separator** (`b"stellar-wrap-v1"`) followed by
+   `payload_version: u32` as the first two elements of every signed payload.
 2. Rejecting any `mint_wrap` call where the provided `payload_version` does not
    equal `CURRENT_PAYLOAD_VERSION` (currently `1`) — it panics with
-   `Error(Contract, #5)` / ContractError::InvalidSignature`).
+   `Error(Contract, #5)` / `ContractError::InvalidSignature`.
 
 **On-chain payload (v1):
 ```
-payload = XDR(payload_version: u32)
+payload = b"stellar-wrap-v1"                   // domain separator (15 bytes)
+        ‖ XDR(payload_version: u32)             // currently 1
         ‖ XDR(contract_address)
         ‖ XDR(user)
         ‖ XDR(period)
@@ -276,22 +317,23 @@ payload = XDR(payload_version: u32)
 ### On-chain Version Evolution Rules
 - **Rust location:** `src/mint.rs:8` (`CURRENT_PAYLOAD_VERSION = 1`)
 - **Validation:** `src/mint.rs:19-23` (`validate_payload_version`)
-- **Prepend order:** `src/mint.rs:42` (version is the first field in the payload)
+- **Payload construction:** `src/signature.rs` (`construct_mint_payload`) — domain separator + version are the first bytes
 
 ### Backend Migration Checklist
 
 #### Step 1 — Contract upgrade (Soroban CLI)
 
 Bump the version number in `src/mint.rs:8` (`CURRENT_PAYLOAD_VERSION = 1 -> 2`),
-then redeploy the WASM via `soroban contract upgrade`, and finally update the payload schema
-(see `Makefile` targets. Deploy via `soroban contract upgrade`).
+then redeploy the WASM via `soroban contract upgrade`, and update the payload schema
+(see `Makefile` targets).
 
-#### Step 2 — Backend signing code (pdate
-When the new contract lands on-chain, update the backend signer to prepend the new
+#### Step 2 — Backend signing code update
+
+When the new contract lands on-chain, update the backend signer to include the new
 version:
 
 ```python
-# BEFORE (no version prefix)
+# BEFORE (no version prefix — old format)
 payload = (
     contract.to_xdr()
     + user.to_xdr()
@@ -301,10 +343,12 @@ payload = (
 )
 signature = admin_ed25519_sign(payload)
 
-# AFTER — prepend payload_version as a LE u32 XDR-encoded
+# AFTER — prepend domain separator and payload_version
+DOMAIN_SEPARATOR = b"stellar-wrap-v1"
 payload_version = 2  # MUST match CURRENT_PAYLOAD_VERSION in src/mint.rs
 payload = (
-    xdr_u32(payload_version)
+    DOMAIN_SEPARATOR
+    + xdr_u32(payload_version)
     + contract.to_xdr()
     + user.to_xdr()
     + period.to_xdr()
@@ -314,30 +358,36 @@ payload = (
 signature = admin_ed25519_sign(payload)
 ```
 
-```
-* Order matters: payload_version MUST be the first bytes in the serialized buffer,
-because the contract appends it in `src/mint.rs:42`.
+> **Order matters:** The domain separator MUST be first, followed immediately by `payload_version`,
+> because the contract constructs the payload in that exact order in `src/signature.rs`.
 
-#### Step 3 — Cutover & dual-signing)
+#### Step 3 — Cutover & dual-signing
 
-To avoid a race windows during the WASM upgrade:
-1. Roll out backend code accepts old-style signatures to accept both versions while the network still only
-   old contract:
-     - *Option A — Deploy in two phases:
-     first deploy a "accepts both v1 and v2 signatures (by temporarily
-        wideningvalidate_payload_version to accept an allow list), then
-        swap back once backend clients.
-     - *Option B (simpler, recommended — Perform the contract upgrade in a
-        single ledger window; do not send mints during the swap.  Ledger
-        sequenced to
-#### Step 4 ) Verify against replay safety
+To avoid a race window during the WASM upgrade:
+1. First deploy backend code that temporarily accepts both old and new payload versions,
+   keeping the existing contract unchanged.
+2. Upgrade the contract to only accept the new version.
+3. Once all backend clients have migrated, remove backward compatibility from the backend.
+
+*Option A — Two-phase deploy:*
+First deploy a contract version that accepts both v1 and v2 signatures (by
+widening `validate_payload_version` to accept an allow list), then swap back
+once all backend clients have migrated.
+
+*Option B (simpler, recommended):*
+Perform the contract upgrade in a single ledger window; do not send mints
+during the swap. Sequence the upgrade so that backend switches to signing
+v2 first, then the contract is upgraded.
+
+#### Step 4 — Verify against replay safety
+
 After upgrade:
 ```bash
-cargo test test_cross_version_replay  # run the version-gating tests added
+cargo test test_cross_version_replay  # run the version-gating tests
 cargo test test::test_same_version_sig_succeeds
 ```
 
-Tests added covering the attack vectors:
+Tests covering the attack vectors:
 
 | Test | Attack | Result |
 |------|--------|--------|


### PR DESCRIPTION
## Overview

This PR addresses two documentation issues to bring the security recommendations and upgrade documentation in line with the current contract implementation.

## Related Issues

Closes #221
Closes #223

## Changes

### Security Recommendations Refresh (Issue #221)

- **[MODIFY]** `SECURITY_RECOMMENDATIONS.md`
  - Removed references to the old unconditional `verify_signature()` stub
  - Updated payload construction to include the domain separator (`b"stellar-wrap-v1"`) and `payload_version: u32` field
  - Replaced the on-chain verification code snippet with the actual `verify_mint_signature()` and `construct_mint_payload()` functions from `src/signature.rs`
  - Updated the TypeScript off-chain signing example to include domain separator and `payloadVersion` parameter
  - Fixed cross-contract replay description to accurately reflect that contract_address is included in the payload (not necessarily the first field)
  - Rewrote the Payload Versioning & Backend Migration section to account for the domain separator and fixed malformed markdown/typos

### Upgrade Runbook Addition (Issue #223)

- **[ADD]** `README.md` - Comprehensive upgrade runbook section covering:
  - How `upgrade(new_wasm_hash)` works (admin authorization, audit event, storage preservation)
  - Step 1: Build the new WASM (with reproducible build notes)
  - Step 2: Upload and capture the WASM hash (CLI and Makefile options)
  - Step 3: Admin-authorized upgrade invocation
  - Step 4: Verification with 4 smoke checks (health, storage preservation, migration, test mint)
  - Failure modes table (NotInitialized, Unauthorized, wrong hash, etc.)
  - Upgrade compatibility rules (migration versioning)
  - Key security considerations (admin-only, audit trail, rollback)

## Verification Results

```
git diff --stat
README.md                   | 199 ++++++++++++++++++++++++++++++++--
SECURITY_RECOMMENDATIONS.md | 156 ++++++++++++++++++----------
 2 files changed, 297 insertions(+), 58 deletions(-)
```

| Acceptance Criteria | Status |
| --- | --- |
| Remove/update references to unconditional verify_signature() stub | Completed - now references actual src/signature.rs implementation |
| Document current Ed25519 verification path | Completed - full payload construction, on-chain verification code, and off-chain signing example updated |
| Clearly separate completed security work from remaining recommendations | Completed - already well-structured with Implemented and Remaining Pre-Mainnet Items sections |
| Runbook covers upload, hash capture, admin authorization, post-upgrade smoke checks | Completed - Steps 1-4 with CLI commands and verification procedures |
| Runbook explains that storage is preserved | Completed - explicitly documented in How it works and Failure modes |
| Failure modes documented for wrong hash or missing admin auth | Completed - complete failure modes table with symptoms, causes, and resolutions |
