### PR TITLE
Refactor token-related functions into a new module and update references

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod revoke;
 mod signature;
 mod storage_types;
 mod storage_accounting;
+mod token;
 
 pub use errors::ContractError;
 pub use storage_types::{ContractHealth, DataKey, WrapLifecycleFSM, WrapRecord, WrapState};
@@ -268,15 +269,15 @@ impl StellarWrapContract {
     }
 
     pub fn name(e: Env) -> String {
-        queries::name(e)
+        token::name(e)
     }
 
     pub fn symbol(e: Env) -> String {
-        queries::symbol(e)
+        token::symbol(e)
     }
 
     pub fn decimals(e: Env) -> u32 {
-        queries::decimals(e)
+        token::decimals(e)
     }
 
     pub fn revoke_wrap(e: Env, user: Address, period: u64, reason_hash: BytesN<32>) {

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -1,5 +1,5 @@
 use crate::{ContractHealth, DataKey, WrapRecord};
-use soroban_sdk::{Address, Bytes, BytesN, Env, String};
+use soroban_sdk::{Address, Bytes, BytesN, Env};
 
 pub(crate) fn get_wrap(e: Env, user: Address, period: u64) -> Option<WrapRecord> {
     e.storage().persistent().get(&DataKey::Wrap(user, period))
@@ -86,20 +86,3 @@ pub(crate) fn total_revoked(e: Env) -> u64 {
         .unwrap_or(0)
 }
 
-pub(crate) fn name(e: Env) -> String {
-    e.storage()
-        .instance()
-        .get(&DataKey::Name)
-        .unwrap_or_else(|| String::from_str(&e, "Stellar Wrap Registry"))
-}
-
-pub(crate) fn symbol(e: Env) -> String {
-    e.storage()
-        .instance()
-        .get(&DataKey::Symbol)
-        .unwrap_or_else(|| String::from_str(&e, "WRAP"))
-}
-
-pub(crate) fn decimals(_e: Env) -> u32 {
-    0
-}

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,0 +1,20 @@
+use crate::DataKey;
+use soroban_sdk::{Env, String};
+
+pub(crate) fn name(e: Env) -> String {
+    e.storage()
+        .instance()
+        .get(&DataKey::Name)
+        .unwrap_or_else(|| String::from_str(&e, "Stellar Wrap Registry"))
+}
+
+pub(crate) fn symbol(e: Env) -> String {
+    e.storage()
+        .instance()
+        .get(&DataKey::Symbol)
+        .unwrap_or_else(|| String::from_str(&e, "WRAP"))
+}
+
+pub(crate) fn decimals(_e: Env) -> u32 {
+    0
+}


### PR DESCRIPTION
#closes
#461 

Description
We need to: Move the name(), symbol(), and decimals() functions to a separate token.rs module.

Acceptance Criteria
 The described changes are implemented.
 The code compiles successfully without warnings.
 Tests pass (if applicable).