### PR TITLE
Add unit test for update_admin by current admin (success)

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -361,6 +361,32 @@ fn test_update_admin_success() {
 }
 
 #[test]
+fn test_update_admin_by_current_admin_succeeds() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_admin",
+            args: (&new_admin,).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.update_admin(&new_admin);
+    assert_eq!(client.get_admin().unwrap(), new_admin);
+}
+
+#[test]
 fn test_token_metadata() {
     let env = Env::default();
     let contract_id = env.register_contract(None, StellarWrapContract);


### PR DESCRIPTION
Description
Adds a unit test verifying that update_admin succeeds when called by the current admin with proper authorization.
Changes
- Added test_update_admin_by_current_admin_succeeds in src/test.rs:364:
- Initializes the contract with an admin
- Uses env.mock_auths to explicitly authorize the current admin for the update_admin invocation (instead of blanket mock_all_auths)
- Calls client.update_admin(&new_admin)
- Asserts the admin was updated to new_admin
Closes #474