### PR TITLE
Add metadata fields (description, image_url) to WrapRecord

### DIFF
--- a/src/mint.rs
+++ b/src/mint.rs
@@ -70,6 +70,8 @@ pub(crate) fn mint_wrap(
         archetype: archetype.clone(),
         period,
         fsm: WrapLifecycleFSM::new(WrapState::Active, now),
+        description: None,
+        image_url: None,
     };
 
     e.storage().persistent().set(&wrap_key, &record);

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 extern crate std;
-use soroban_sdk::{contracttype, Address, BytesN, Symbol};
+use soroban_sdk::{contracttype, Address, BytesN, String, Symbol};
 
 #[contracttype]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -58,6 +58,8 @@ pub struct WrapRecord {
     pub archetype: Symbol,
     pub period: u64, // Standardized to u64 for better indexing/sorting
     pub fsm: WrapLifecycleFSM,
+    pub description: Option<String>,
+    pub image_url: Option<String>,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Summary

This PR adds optional metadata fields to the `WrapRecord` struct to support storing additional information about wrap records, specifically a description and an image URL.

## Changes

### `src/storage_types.rs`

Added two new optional fields to `WrapRecord`:

- `pub description: Option<String>` — Optional description text
- `pub image_url: Option<String>` — Optional image URL

Also added the `String` import from `soroban_sdk` to support the new fields.

### `src/mint.rs`

Updated the `mint_wrap` function to initialize the new metadata fields:

- Both `description` and `image_url` are set to `None` when creating new wrap records.
- This maintains backward compatibility while allowing future enhancements to populate these fields.

## Acceptance Criteria

- ✅ Metadata fields (`description`, `image_url`) added to the `WrapRecord` struct
- ✅ Code compiles successfully without errors
- ✅ Fields are properly initialized in the `mint_wrap` function
- ✅ Changes are backward compatible through the use of `Option` types

## Testing

- Library code compiles successfully with:

  ```bash
  cargo check --lib

## Closes #511 