### PR TITLE
test: assert balance_of returns zero before initialize

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -2529,3 +2529,24 @@ fn test_set_alias_hash_requires_auth() {
     let dummy_wasm_hash = BytesN::from_array(&env, &[0xBBu8; 32]);
     client.upgrade(&dummy_wasm_hash);
 }
+
+/// `balance_of` returns zero for any user before `initialize` is called.
+///
+/// This is intentional and safe: `balance_of` is a read-only query that
+/// reads the `WrapCount` persistent storage key for the user, returning
+/// `unwrap_or(0)` when the key is absent. Because the function neither
+/// mutates state nor requires authorization, there is no security risk in
+/// allowing calls before the contract is initialized. The behavior mirrors
+/// standard token semantics where a new address has zero balance.
+#[test]
+fn test_balance_of_before_initialize() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+
+    // Contract is NOT initialized — no admin, no signing key.
+    // balance_of must still return 0 without panicking.
+    assert_eq!(client.balance_of(&user), 0);
+}


### PR DESCRIPTION
## Closes #243 

Adds test_balance_of_before_initialize to lock in the read-only pre-init behavior of balance_of. The function uses unwrap_or(0) on absent storage, so it safely returns 0 for any user regardless of contract initialization state. The test confirms this without calling initialize, and the doc comment explains why the behavior is intentionally safe (no state mutation, no auth required).

Closes issue.md acceptance criteria.