### PR TITLE
fix: fall back to previous wrap after latest revocation

### DIFF
--- a/src/queries.rs
+++ b/src/queries.rs
@@ -39,28 +39,75 @@ pub(crate) fn verify_data(e: Env, user: Address, period: u64, data: Bytes) -> bo
 
 pub(crate) fn get_latest_wrap(e: Env, user: Address) -> Option<WrapRecord> {
     let latest_key = DataKey::LatestPeriod(user.clone());
-    let period: u64 = e.storage().persistent().get(&latest_key)?;
-    e.storage().persistent().get(&DataKey::Wrap(user, period))
+    if let Some(period) = e.storage().persistent().get::<_, u64>(&latest_key) {
+        if let Some(wrap) = e
+            .storage()
+            .persistent()
+            .get(&DataKey::Wrap(user.clone(), period))
+        {
+            return Some(wrap);
+        }
+    }
+
+    // A revoked latest record clears the marker but leaves older periods intact.
+    let periods: soroban_sdk::Vec<u64> = e
+        .storage()
+        .persistent()
+        .get(&DataKey::UserPeriods(user.clone()))?;
+    let mut latest: Option<WrapRecord> = None;
+
+    for index in 0..periods.len() {
+        if let Some(period) = periods.get(index) {
+            if let Some(wrap) = e
+                .storage()
+                .persistent()
+                .get::<_, WrapRecord>(&DataKey::Wrap(user.clone(), period))
+            {
+                let is_newer = match latest.as_ref() {
+                    None => true,
+                    Some(current) => wrap.period > current.period,
+                };
+                if is_newer {
+                    latest = Some(wrap);
+                }
+            }
+        }
+    }
+
+    latest
 }
 
-pub(crate) fn get_wraps(e: Env, user: Address, start: u32, limit: u32) -> soroban_sdk::Vec<WrapRecord> {
+pub(crate) fn get_wraps(
+    e: Env,
+    user: Address,
+    start: u32,
+    limit: u32,
+) -> soroban_sdk::Vec<WrapRecord> {
     let mut results = soroban_sdk::Vec::new(&e);
     let user_periods_key = DataKey::UserPeriods(user.clone());
-    
-    if let Some(periods) = e.storage().persistent().get::<_, soroban_sdk::Vec<u64>>(&user_periods_key) {
+
+    if let Some(periods) = e
+        .storage()
+        .persistent()
+        .get::<_, soroban_sdk::Vec<u64>>(&user_periods_key)
+    {
         let len = periods.len();
         if start < len {
             let end = core::cmp::min(start.saturating_add(limit), len);
             for i in start..end {
                 if let Some(period) = periods.get(i) {
-                    if let Some(wrap) = e.storage().persistent().get(&DataKey::Wrap(user.clone(), period)) {
+                    if let Some(wrap) = e
+                        .storage()
+                        .persistent()
+                        .get(&DataKey::Wrap(user.clone(), period))
+                    {
                         results.push_back(wrap);
                     }
                 }
             }
         }
     }
-    
+
     results
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -2220,14 +2220,20 @@ fn test_update_admin_pubkey_emits_event() {
     client.mint_wrap(&user, &202401, &archetype, &hash1, &CURRENT_PAYLOAD_VERSION, &sig1);
     client.mint_wrap(&user, &202402, &archetype, &hash2, &CURRENT_PAYLOAD_VERSION, &sig2);
 
+    assert_eq!(client.get_wrap(&user, &202401).unwrap().data_hash, hash1);
+    assert_eq!(client.get_wrap(&user, &202402).unwrap().data_hash, hash2);
     let latest = client.get_latest_wrap(&user).unwrap();
     assert_eq!(latest.period, 202402);
 
     let reason_hash = BytesN::from_array(&env, &[0u8; 32]);
     client.revoke_wrap(&user, &202402, &reason_hash);
 
-    // LatestPeriod was cleared; get_latest_wrap returns None
-    assert!(client.get_latest_wrap(&user).is_none());
+    assert_eq!(client.get_wrap(&user, &202401).unwrap().data_hash, hash1);
+    assert!(client.get_wrap(&user, &202402).is_none());
+    // LatestPeriod was cleared; get_latest_wrap falls back to the older wrap.
+    let latest = client.get_latest_wrap(&user).unwrap();
+    assert_eq!(latest.period, 202401);
+    assert_eq!(latest.data_hash, hash1);
     assert_eq!(client.balance_of(&user), 1);
 }
 


### PR DESCRIPTION
## Summary

- keep the `LatestPeriod` fast path when its record is present
- fall back through tracked user periods when the latest record was revoked
- return the highest remaining wrap while skipping removed records
- extend the existing revocation scenario to cover records, balance, and latest fallback

## Testing

- `cargo check --lib`
- `cargo clippy --lib`
- `rustfmt --check src/queries.rs`
- `git diff --check origin/main...HEAD`

The repository's existing `src/test.rs` currently has unmatched delimiters on `main`, so `cargo test --lib` is blocked before tests execute.

Closes #238