### PR TITLE
ci: add dedicated cargo clippy workflow (#503)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,13 +27,9 @@ jobs:
     - name: Check format
       run: cargo fmt --check
     - name: Run clippy
-<<<<<<< HEAD
       run: cargo clippy --all-targets -- -D warnings
-=======
-      run: cargo clippy -- -D warnings
     - name: Check doc compilation
       run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
->>>>>>> ci/add-cargo-doc-check
     - name: Run tests
       run: cargo test
     - name: Clean test snapshots

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,20 @@
+name: Cargo Clippy
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  clippy:
+    name: Cargo Clippy Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
## Summary

This PR adds a dedicated **Cargo Clippy** GitHub Actions workflow, allowing clippy lint checks to run as a standalone CI check. Modeled after the existing `fmt.yml` pattern, this provides faster, clearer feedback specifically for clippy issues in PRs.

## Changes

### 1. New: `.github/workflows/clippy.yml`

A dedicated workflow for `cargo clippy` that:
- **Triggers on:** `push` and `pull_request` targeting the `main` branch
- **Runner:** `ubuntu-latest`
- **Steps:**
  1. Checkout with `actions/checkout@v4`
  2. Install Rust using `dtolnay/rust-toolchain@stable` with the `clippy` component
  3. Run `cargo clippy --all-targets -- -D warnings`

This follows the exact same conventions established by `.github/workflows/fmt.yml` (the existing dedicated formatter check workflow).

### 2. Fixed: `.github/workflows/ci.yml`

Resolved an unresolved merge conflict between `HEAD` and the `ci/add-cargo-doc-check` branch:
- **Kept:** `--all-targets` flag on the clippy command (for comprehensive lint coverage across all targets — lib, bin, test, bench, etc.)
- **Added:** The doc compilation check step (`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`) from the incoming branch

## Design Decisions

| Decision | Rationale |
|---|---|
| Dedicated workflow (rather than only in `ci.yml`) | Matching the existing `fmt.yml` pattern. CI checks that run as separate workflows provide clearer signal in PR status checks — a contributor can see at a glance whether the failure is from formatting, linting, or tests. |
| `--all-targets` flag | Ensures clippy lints all compilation targets (tests, examples, benches, etc.), not just the library. Catches issues in test code that `cargo clippy` alone would miss. |
| `components: clippy` in toolchain setup | Explicitly requests the clippy component for reproducibility, matching the `components: rustfmt` usage in `fmt.yml`. |

## Verification

- [x] Merge conflict in `ci.yml` resolved cleanly
- [x] New `clippy.yml` follows the exact structure and conventions of the existing `fmt.yml`
- [x] `cargo clippy --all-targets -- -D warnings` passes with zero warnings locally
- [x] YAML syntax is valid

## Related

Closes #503