### PR TITLE
feat(#516): Implement staking mechanism for wrap priority

### DIFF
--- a/STORAGE.md
+++ b/STORAGE.md
@@ -295,16 +295,58 @@ So:
 
 ---
 
-## 8) Summary table of DataKey variants
+## 8) Staking mechanism storage
+
+The staking feature (`src/stake.rs`) lets users stake tokens to earn fee
+priority when minting wraps. It uses the following persistent and instance
+storage keys:
+
+### Persistent storage (per user)
+
+- `DataKey::Stake(Address)` → `StakeRecord`
+  - `amount: i128` — currently staked amount
+  - `staked_at: u64` — ledger timestamp when first staked
+  - `unstaking_at: u64` — 0 when active; non-zero when unstake initiated
+
+TTL is extended to ~1 year on every write (`stake`, `unstake`).
+
+### Instance storage (shared)
+
+- `DataKey::StakeConfig` → `StakeConfig`
+  - `min_stake: i128` — minimum stake amount (default: 100)
+  - `cooldown_seconds: u64` — withdrawal delay after unstaking (default: 7 days)
+  - `priority_multiplier_bps: u32` — discount per `min_stake` multiple (default: 1000 = 10%)
+  - `max_priority_bps: u32` — maximum discount cap (default: 5000 = 50%)
+- `DataKey::TotalStaked` → `i128` — aggregate of all users' staked amounts
+
+### Priority calculation
+
+`priority = min( (amount / min_stake) * priority_multiplier_bps, max_priority_bps )`
+
+Users with no stake or an active unstake receive 0 priority (no discount).
+
+### Fee discount
+
+`discounted_fee = raw_fee - (raw_fee * priority_bps / 10_000)`
+
+The `get_discounted_fee` query applies the user's priority to the raw fee
+returned by `compute_current_fee`.
+
+---
+
+## 9) Summary table of DataKey variants
 
 | DataKey variant | Tier | Value type | TTL setting | Notes |
 |---|---|---|---|---|
 | `Admin` | instance | `Address` | shared instance lifecycle | set once during `initialize()` |
 | `AdminPubKey` | instance | `BytesN<32>` | shared instance lifecycle | set once during `initialize()` |
+| `PendingAdmin` | instance | `Address` | shared instance lifecycle | set during two-step admin transfer |
 | `Wrap(Address, u64)` | persistent | `WrapRecord` | `extend_ttl(..., ttl_one_year, ttl_one_year)` | exists per `(user, period)`; duplicated check uses `has()` |
 | `WrapCount(Address)` | persistent | `u32` | `extend_ttl(..., ttl_one_year, ttl_one_year)` | incremented each `mint_wrap()` |
 | `LatestPeriod(Address)` | persistent | `u64` | `extend_ttl(..., ttl_one_year, ttl_one_year)` only when updated | updated when `period` increases |
-| `MintGuard(Address)` | temporary | `bool` (stored as `true`) | auto-cleaned (temporary TTL) | removed explicitly on success |
+| `Stake(Address)` | persistent | `StakeRecord` | `extend_ttl(..., ttl_one_year, ttl_one_year)` on write | tracks user's staking position |
+| `StakeConfig` | instance | `StakeConfig` | shared instance lifecycle | admin-configurable staking parameters |
+| `TotalStaked` | instance | `i128` | shared instance lifecycle | aggregate of all staked amounts |
 
 ---
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,4 +18,12 @@ pub enum ContractError {
     Paused = 12,
     ArithmeticOverflow = 13,
     InvalidFeeParams = 14,
+    // Staking errors
+    StakeTooLow = 15,
+    StakeNotFound = 16,
+    StakeCooldownActive = 17,
+    StakeNotUnstaking = 18,
+    StakeCooldownNotElapsed = 19,
+    InvalidStakeConfig = 20,
+    StakeArithmeticOverflow = 21,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #[cfg(test)]
 extern crate std;
 
-use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Bytes, BytesN, Env, String, Symbol};
+use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Bytes, BytesN, Env, String};
 
 mod admin;
 mod alias;
@@ -26,11 +26,12 @@ mod mint;
 mod queries;
 mod revoke;
 mod signature;
+mod stake;
 mod storage_types;
 mod storage_accounting;
 
 pub use errors::ContractError;
-pub use storage_types::{ContractHealth, DataKey, WrapLifecycleFSM, WrapRecord, WrapState};
+pub use storage_types::{ContractHealth, DataKey, StakeConfig, StakeRecord, WrapLifecycleFSM, WrapRecord, WrapState};
 
 #[contract]
 pub struct StellarWrapContract;
@@ -306,10 +307,91 @@ impl StellarWrapContract {
     pub fn fee_params(e: Env) -> storage_types::FeeParams {
         storage_accounting::get_fee_params(&e)
     }
+
+    // ── Staking ──────────────────────────────────────────────────────────
+
+    /// Stake tokens to earn wrap fee priority.
+    ///
+    /// The amount must be at least the configured `min_stake`. Staking more
+    /// tokens increases the user's priority, which translates to a fee
+    /// discount (in basis points) when minting wraps.
+    ///
+    /// # Authorization
+    /// `user` must authorize the call.
+    pub fn stake(e: Env, user: Address, amount: i128) {
+        stake::stake(e, user, amount);
+    }
+
+    /// Initiate the unstaking process.
+    ///
+    /// After calling this, the user must wait for the cooldown period
+    /// (configured in `StakeConfig`) before they can withdraw their stake
+    /// via [`withdraw_stake`].
+    ///
+    /// While unstaking is in progress, the user receives no fee priority.
+    ///
+    /// # Authorization
+    /// `user` must authorize the call.
+    pub fn unstake(e: Env, user: Address) {
+        stake::unstake(e, user);
+    }
+
+    /// Complete the unstaking process and withdraw staked funds.
+    ///
+    /// Can only be called after the cooldown period has elapsed since
+    /// [`unstake`] was called.
+    ///
+    /// # Authorization
+    /// `user` must authorize the call.
+    pub fn withdraw_stake(e: Env, user: Address) {
+        stake::withdraw_stake(e, user);
+    }
+
+    /// Return the staking record for `user`, or `None` if they have not staked.
+    pub fn get_stake(e: Env, user: Address) -> Option<StakeRecord> {
+        stake::get_stake(&e, user)
+    }
+
+    /// Return the fee-discount priority (in basis points) for `user`.
+    ///
+    /// Returns 0 if the user has no active stake.
+    pub fn get_stake_priority(e: Env, user: Address) -> u32 {
+        stake::get_stake_priority(&e, user)
+    }
+
+    /// Return the total amount staked across all users.
+    pub fn total_staked(e: Env) -> i128 {
+        stake::get_total_staked(&e)
+    }
+
+    /// Admin: set the staking configuration.
+    ///
+    /// # Panics
+    /// - If `min_stake == 0` or `cooldown_seconds == 0`
+    /// - If `max_priority_bps > 10_000`
+    pub fn set_stake_config(e: Env, config: StakeConfig) {
+        stake::set_stake_config(&e, config);
+    }
+
+    /// Return the current staking configuration.
+    pub fn get_stake_config(e: Env) -> StakeConfig {
+        stake::get_stake_config(&e)
+    }
+
+    /// Return the discounted fee for `user`, taking their stake priority
+    /// into account.
+    ///
+    /// Users with active stakes receive a percentage discount based on
+    /// their priority score. Users without stakes see the raw fee.
+    pub fn get_discounted_fee(e: Env, user: Address) -> i128 {
+        stake::get_discounted_fee(&e, user)
+    }
 }
 
 #[cfg(test)]
 mod security_test;
+#[cfg(test)]
+mod stake_test;
 #[cfg(test)]
 mod test;
 #[cfg(test)]

--- a/src/stake.rs
+++ b/src/stake.rs
@@ -1,0 +1,297 @@
+//! # Staking mechanism for Wrap priority
+//!
+//! Users can stake tokens to earn fee discounts (priority) when minting wraps.
+//! The discount is calculated based on the amount staked relative to the
+//! admin-configured `min_stake`. A cooldown period applies before unstaked
+//! funds can be withdrawn.
+
+use soroban_sdk::{panic_with_error, symbol_short, Address, Env};
+
+use crate::storage_types::{StakeConfig, StakeRecord};
+use crate::{ContractError, DataKey};
+
+const DEFAULT_MIN_STAKE: i128 = 100;
+const DEFAULT_COOLDOWN_SECONDS: u64 = 7 * 24 * 60 * 60; // 7 days
+const DEFAULT_PRIORITY_MULTIPLIER_BPS: u32 = 1_000; // 10% per min_stake unit above minimum
+const DEFAULT_MAX_PRIORITY_BPS: u32 = 5_000; // 50% max discount
+const TTL_ONE_YEAR: u32 = 17_280 * 365; // ~1 year in ledgers
+
+// ── Config helpers ──────────────────────────────────────────────────────────
+
+/// Read the current stake config from instance storage, falling back to
+/// sensible defaults when none has been set.
+fn read_stake_config(e: &Env) -> StakeConfig {
+    e.storage()
+        .instance()
+        .get(&DataKey::StakeConfig)
+        .unwrap_or(StakeConfig {
+            min_stake: DEFAULT_MIN_STAKE,
+            cooldown_seconds: DEFAULT_COOLDOWN_SECONDS,
+            priority_multiplier_bps: DEFAULT_PRIORITY_MULTIPLIER_BPS,
+            max_priority_bps: DEFAULT_MAX_PRIORITY_BPS,
+        })
+}
+
+// ── Internal helpers ────────────────────────────────────────────────────────
+
+/// Read the stake record for `user`, returning `None` if not found.
+fn read_stake(e: &Env, user: &Address) -> Option<StakeRecord> {
+    e.storage().persistent().get(&DataKey::Stake(user.clone()))
+}
+
+fn write_stake(e: &Env, user: &Address, record: &StakeRecord) {
+    let key = DataKey::Stake(user.clone());
+    e.storage().persistent().set(&key, record);
+    e.storage()
+        .persistent()
+        .extend_ttl(&key, TTL_ONE_YEAR, TTL_ONE_YEAR);
+}
+
+fn remove_stake(e: &Env, user: &Address) {
+    e.storage().persistent().remove(&DataKey::Stake(user.clone()));
+}
+
+fn read_total_staked(e: &Env) -> i128 {
+    e.storage()
+        .instance()
+        .get(&DataKey::TotalStaked)
+        .unwrap_or(0i128)
+}
+
+fn write_total_staked(e: &Env, amount: i128) {
+    e.storage().instance().set(&DataKey::TotalStaked, &amount);
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+/// Stake tokens for `user`.
+///
+/// # Authorization
+/// `user` must authorize the call (`user.require_auth()`).
+///
+/// # Panics
+/// - [`ContractError::StakeTooLow`] if `amount < config.min_stake`.
+/// - [`ContractError::StakeCooldownActive`] if an unstake is already in progress.
+/// - [`ContractError::StakeArithmeticOverflow`] on total overflow.
+pub(crate) fn stake(e: Env, user: Address, amount: i128) {
+    crate::admin::require_not_paused(&e);
+    user.require_auth();
+
+    let config = read_stake_config(&e);
+
+    if amount < config.min_stake {
+        panic_with_error!(e, ContractError::StakeTooLow);
+    }
+
+    if let Some(existing) = read_stake(&e, &user) {
+        // If an unstake is already in progress, reject new stakes until resolved.
+        if existing.unstaking_at != 0 {
+            panic_with_error!(e, ContractError::StakeCooldownActive);
+        }
+
+        let new_amount = existing
+            .amount
+            .checked_add(amount)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::StakeArithmeticOverflow));
+
+        let updated = StakeRecord {
+            amount: new_amount,
+            staked_at: existing.staked_at, // keep original stake time
+            unstaking_at: 0,
+        };
+        write_stake(&e, &user, &updated);
+
+        let total = read_total_staked(&e);
+        let new_total = total
+            .checked_add(amount)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::StakeArithmeticOverflow));
+        write_total_staked(&e, new_total);
+
+        e.events()
+            .publish((symbol_short!("stake"), user.clone(), symbol_short!("add")), amount);
+    } else {
+        let now = e.ledger().timestamp();
+        let record = StakeRecord {
+            amount,
+            staked_at: now,
+            unstaking_at: 0,
+        };
+        write_stake(&e, &user, &record);
+
+        let total = read_total_staked(&e);
+        let new_total = total
+            .checked_add(amount)
+            .unwrap_or_else(|| panic_with_error!(e, ContractError::StakeArithmeticOverflow));
+        write_total_staked(&e, new_total);
+
+        e.events()
+            .publish((symbol_short!("stake"), user.clone(), symbol_short!("init")), amount);
+    }
+}
+
+/// Initiate the unstaking process for `user`.
+///
+/// This starts the cooldown timer. After `cooldown_seconds`, the user can
+/// call [`withdraw_stake`] to retrieve their staked amount.
+///
+/// # Authorization
+/// `user` must authorize the call.
+///
+/// # Panics
+/// - [`ContractError::StakeNotFound`] if the user has no active stake.
+/// - [`ContractError::StakeCooldownActive`] if an unstake is already in progress.
+pub(crate) fn unstake(e: Env, user: Address) {
+    crate::admin::require_not_paused(&e);
+    user.require_auth();
+
+    let mut record = read_stake(&e, &user)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::StakeNotFound));
+
+    if record.unstaking_at != 0 {
+        panic_with_error!(e, ContractError::StakeCooldownActive);
+    }
+
+    let now = e.ledger().timestamp();
+    record.unstaking_at = now;
+    write_stake(&e, &user, &record);
+
+    e.events()
+        .publish((symbol_short!("unstake"), user), record.amount);
+}
+
+/// Complete the unstaking process and withdraw staked funds.
+///
+/// Can only be called after the cooldown period has elapsed since
+/// [`unstake`] was called.
+///
+/// # Authorization
+/// `user` must authorize the call.
+///
+/// # Panics
+/// - [`ContractError::StakeNotFound`] if the user has no stake record.
+/// - [`ContractError::StakeNotUnstaking`] if unstake was never initiated.
+/// - [`ContractError::StakeCooldownNotElapsed`] if cooldown hasn't passed.
+pub(crate) fn withdraw_stake(e: Env, user: Address) {
+    crate::admin::require_not_paused(&e);
+    user.require_auth();
+
+    let record = read_stake(&e, &user)
+        .unwrap_or_else(|| panic_with_error!(e, ContractError::StakeNotFound));
+
+    if record.unstaking_at == 0 {
+        panic_with_error!(e, ContractError::StakeNotUnstaking);
+    }
+
+    let config = read_stake_config(&e);
+    let now = e.ledger().timestamp();
+
+    if now.saturating_sub(record.unstaking_at) < config.cooldown_seconds {
+        panic_with_error!(e, ContractError::StakeCooldownNotElapsed);
+    }
+
+    let withdrawn = record.amount;
+
+    let total = read_total_staked(&e);
+    let new_total = total.saturating_sub(withdrawn);
+    write_total_staked(&e, new_total);
+
+    remove_stake(&e, &user);
+
+    e.events()
+        .publish((symbol_short!("withdraw"), user), withdrawn);
+}
+
+// ── Queries ─────────────────────────────────────────────────────────────────
+
+/// Return the stake record for `user`, or `None` if they have not staked.
+pub(crate) fn get_stake(e: &Env, user: Address) -> Option<StakeRecord> {
+    read_stake(e, &user)
+}
+
+/// Compute the fee-discount priority for `user` in basis points.
+///
+/// The priority is calculated as:
+/// `min( (amount / min_stake) * priority_multiplier_bps, max_priority_bps )`
+///
+/// Returns 0 if the user has no stake or is in the unstaking process.
+pub(crate) fn get_stake_priority(e: &Env, user: Address) -> u32 {
+    let record = match read_stake(e, &user) {
+        Some(r) => r,
+        None => return 0,
+    };
+
+    // No priority during an active unstake.
+    if record.unstaking_at != 0 {
+        return 0;
+    }
+
+    let config = read_stake_config(e);
+    if config.min_stake == 0 || record.amount < config.min_stake {
+        return 0;
+    }
+
+    // Calculate how many multiples of min_stake the user has staked.
+    let multiples = (record.amount / config.min_stake) as u32;
+    let priority = multiples.saturating_mul(config.priority_multiplier_bps);
+
+    if priority > config.max_priority_bps {
+        config.max_priority_bps
+    } else {
+        priority
+    }
+}
+
+/// Return the total amount staked across all users.
+pub(crate) fn get_total_staked(e: &Env) -> i128 {
+    read_total_staked(e)
+}
+
+/// Admin: set the staking configuration parameters.
+///
+/// # Panics
+/// - [`ContractError::InvalidStakeConfig`] if `min_stake == 0` or
+///   `cooldown_seconds == 0` or `max_priority_bps > 10_000`.
+pub(crate) fn set_stake_config(e: &Env, config: StakeConfig) {
+    crate::admin::read_admin(e).require_auth();
+
+    if config.min_stake == 0 || config.cooldown_seconds == 0 || config.max_priority_bps > 10_000 {
+        panic_with_error!(e, ContractError::InvalidStakeConfig);
+    }
+
+    e.storage().instance().set(&DataKey::StakeConfig, &config);
+
+    e.events()
+        .publish((symbol_short!("stake"), symbol_short!("cfg")), config);
+}
+
+/// Return the current staking configuration.
+pub(crate) fn get_stake_config(e: &Env) -> StakeConfig {
+    read_stake_config(e)
+}
+
+// ── Priority-aware fee computation ──────────────────────────────────────────
+
+/// Compute the discounted fee for `user` based on their staking priority.
+///
+/// Applies the user's stake priority (in basis points) as a percentage
+/// discount to the raw fee returned by [`crate::storage_accounting::compute_current_fee`].
+///
+/// # Returns
+/// The fee after applying the staking discount. Returns 0 if the discount
+/// would exceed the fee (i.e., staking can reduce the fee to zero, but not
+/// below).
+pub(crate) fn get_discounted_fee(e: &Env, user: Address) -> i128 {
+    let raw_fee = crate::storage_accounting::compute_current_fee(e);
+    let priority_bps = get_stake_priority(e, user);
+
+    if priority_bps == 0 || raw_fee <= 0 {
+        return raw_fee;
+    }
+
+    // discount = raw_fee * priority_bps / 10000
+    let discount = raw_fee
+        .saturating_mul(priority_bps as i128)
+        .saturating_div(10_000);
+
+    raw_fee.saturating_sub(discount)
+}

--- a/src/stake_test.rs
+++ b/src/stake_test.rs
@@ -1,0 +1,493 @@
+#![cfg(test)]
+
+extern crate std;
+
+use super::*;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events},
+    Address, BytesN, Env,
+};
+
+// ── Stake tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_stake_basic_flow() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // Initially no stake
+    assert!(client.get_stake(&user).is_none());
+    assert_eq!(client.total_staked(), 0);
+    assert_eq!(client.get_stake_priority(&user), 0);
+
+    // Stake 500 tokens
+    client.stake(&user, &500);
+    let record = client.get_stake(&user).unwrap();
+    assert_eq!(record.amount, 500);
+    assert_eq!(record.unstaking_at, 0);
+    assert!(record.staked_at > 0);
+    assert_eq!(client.total_staked(), 500);
+}
+
+#[test]
+fn test_stake_multiple_times_accumulates() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.stake(&user, &100);
+    client.stake(&user, &200);
+    client.stake(&user, &300);
+
+    let record = client.get_stake(&user).unwrap();
+    assert_eq!(record.amount, 600);
+    assert_eq!(client.total_staked(), 600);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #15)")]
+fn test_stake_below_minimum_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // Default min_stake is 100, try staking 50
+    client.stake(&user, &50);
+}
+
+#[test]
+fn test_unstake_and_withdraw_flow() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.stake(&user, &1000);
+
+    // Initiate unstake
+    client.unstake(&user);
+    let record = client.get_stake(&user).unwrap();
+    assert_eq!(record.amount, 1000);
+    assert!(record.unstaking_at > 0);
+
+    // Priority should be 0 during unstaking
+    assert_eq!(client.get_stake_priority(&user), 0);
+
+    // Advance time past cooldown (default 7 days = 604800 seconds)
+    env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + 604801;
+    });
+
+    // Withdraw
+    client.withdraw_stake(&user);
+    assert!(client.get_stake(&user).is_none());
+    assert_eq!(client.total_staked(), 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #19)")]
+fn test_withdraw_before_cooldown_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.stake(&user, &1000);
+    client.unstake(&user);
+
+    // Try to withdraw immediately (no time passed)
+    client.withdraw_stake(&user);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #16)")]
+fn test_unstake_nonexistent_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.unstake(&user);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #17)")]
+fn test_double_unstake_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.stake(&user, &500);
+    client.unstake(&user);
+    client.unstake(&user); // Should panic: cooldown already active
+}
+
+#[test]
+fn test_stake_priority_computation() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // Default config: min_stake=100, multiplier=1000bps (10%), max=5000bps (50%)
+    // Stake 100 -> 1x min_stake -> priority = 1 * 1000 = 1000 bps (10%)
+    client.stake(&user, &100);
+    assert_eq!(client.get_stake_priority(&user), 1000);
+
+    // Add more -> 300 total -> 3x min_stake -> 3000 bps (30%)
+    client.stake(&user, &200);
+    assert_eq!(client.get_stake_priority(&user), 3000);
+
+    // Add more -> 600 total -> 6x min_stake -> capped at 5000 bps (50%)
+    client.stake(&user, &300);
+    assert_eq!(client.get_stake_priority(&user), 5000);
+}
+
+#[test]
+fn test_stake_priority_zero_for_non_staker() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+
+    assert_eq!(client.get_stake_priority(&user), 0);
+}
+
+#[test]
+fn test_stake_config_defaults() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+
+    let config = client.get_stake_config();
+    assert_eq!(config.min_stake, 100);
+    assert_eq!(config.cooldown_seconds, 7 * 24 * 60 * 60);
+    assert_eq!(config.priority_multiplier_bps, 1000);
+    assert_eq!(config.max_priority_bps, 5000);
+}
+
+#[test]
+fn test_admin_set_stake_config() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    let new_config = StakeConfig {
+        min_stake: 200,
+        cooldown_seconds: 3600, // 1 hour
+        priority_multiplier_bps: 500,  // 5% per min_stake unit
+        max_priority_bps: 3000, // 30% max
+    };
+    client.set_stake_config(&new_config);
+
+    let config = client.get_stake_config();
+    assert_eq!(config.min_stake, 200);
+    assert_eq!(config.cooldown_seconds, 3600);
+    assert_eq!(config.priority_multiplier_bps, 500);
+    assert_eq!(config.max_priority_bps, 3000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #20)")]
+fn test_invalid_stake_config_zero_min_stake_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    let bad_config = StakeConfig {
+        min_stake: 0,
+        cooldown_seconds: 3600,
+        priority_multiplier_bps: 500,
+        max_priority_bps: 3000,
+    };
+    client.set_stake_config(&bad_config);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #20)")]
+fn test_invalid_stake_config_max_bps_exceeds_10000_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    let bad_config = StakeConfig {
+        min_stake: 100,
+        cooldown_seconds: 3600,
+        priority_multiplier_bps: 500,
+        max_priority_bps: 10001,
+    };
+    client.set_stake_config(&bad_config);
+}
+
+#[test]
+fn test_total_staked_multi_user() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user_a = Address::generate(&env);
+    let user_b = Address::generate(&env);
+    let user_c = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.stake(&user_a, &100);
+    client.stake(&user_b, &200);
+    client.stake(&user_c, &300);
+
+    assert_eq!(client.total_staked(), 600);
+
+    // Unstake and withdraw one
+    client.unstake(&user_b);
+    env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + 604801;
+    });
+    client.withdraw_stake(&user_b);
+
+    assert_eq!(client.total_staked(), 400);
+}
+
+#[test]
+fn test_discounted_fee_with_stake() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // Set up a fee model so there's a non-zero fee
+    let fee_params = storage_types::FeeParams {
+        base_fee: 1000,
+        per_kib_fee: 100,
+        scale_step_kib: 1,
+        max_fee: 10000,
+    };
+    client.set_fee_params(&fee_params);
+
+    // No stake -> no discount
+    let fee_no_stake = client.get_discounted_fee(&user);
+    let raw_fee = client.current_fee();
+    assert_eq!(fee_no_stake, raw_fee);
+
+    // Stake to get ~10% discount (1000 bps priority)
+    client.stake(&user, &100); // 1x min_stake -> 1000 bps = 10%
+    let fee_with_stake = client.get_discounted_fee(&user);
+    assert!(fee_with_stake < fee_no_stake);
+}
+
+#[test]
+fn test_discounted_fee_zero_when_raw_fee_zero() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // Default fee params have base_fee=0 and per_kib_fee=0 -> fee = 0
+    client.stake(&user, &500);
+
+    let discounted = client.get_discounted_fee(&user);
+    assert_eq!(discounted, 0);
+}
+
+#[test]
+fn test_stake_events_emitted() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.stake(&user, &500);
+
+    let events = env.events().all();
+    // Find the stake event
+    let stake_events: Vec<_> = events
+        .iter()
+        .filter(|e| {
+            let topics = &e.1;
+            if topics.len() >= 2 {
+                let t0: Result<soroban_sdk::Symbol, _> = topics.get(0).unwrap().try_into_val(&env);
+                t0.map_or(false, |s| s == symbol_short!("stake"))
+            } else {
+                false
+            }
+        })
+        .collect();
+
+    assert!(!stake_events.is_empty(), "Expected at least one stake event");
+}
+
+#[test]
+fn test_cannot_stake_during_unstaking() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.stake(&user, &200);
+    client.unstake(&user);
+
+    // Try to stake more during unstaking period — should fail
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.stake(&user, &100);
+    }));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_re_stake_after_withdraw() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    // First stake
+    client.stake(&user, &500);
+    assert_eq!(client.get_stake(&user).unwrap().amount, 500);
+
+    // Unstake and withdraw
+    client.unstake(&user);
+    env.ledger().with_mut(|li| {
+        li.timestamp = li.timestamp + 604801;
+    });
+    client.withdraw_stake(&user);
+    assert!(client.get_stake(&user).is_none());
+
+    // Re-stake after withdrawal
+    client.stake(&user, &300);
+    let record = client.get_stake(&user).unwrap();
+    assert_eq!(record.amount, 300);
+    assert_eq!(record.unstaking_at, 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #18)")]
+fn test_withdraw_without_unstake_fails() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let user = Address::generate(&env);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.stake(&user, &500);
+    // Call withdraw without calling unstake first
+    client.withdraw_stake(&user);
+}

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -85,6 +85,32 @@ pub struct FeeParams {
     pub max_fee: i128,
 }
 
+/// Records a user's staking position for wrap priority.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StakeRecord {
+    /// Amount currently staked by the user.
+    pub amount: i128,
+    /// Ledger timestamp when the user first staked.
+    pub staked_at: u64,
+    /// Ledger timestamp when unstake was initiated; 0 means not unstaking.
+    pub unstaking_at: u64,
+}
+
+/// Admin-configurable parameters for the staking mechanism.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StakeConfig {
+    /// Minimum amount a user must stake to participate.
+    pub min_stake: i128,
+    /// Cooldown period (in seconds) before a user can withdraw after unstaking.
+    pub cooldown_seconds: u64,
+    /// Fee discount earned per unit of `min_stake` above the minimum, in basis points.
+    pub priority_multiplier_bps: u32,
+    /// Maximum fee discount from staking, in basis points (e.g. 5000 = 50%).
+    pub max_priority_bps: u32,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -124,4 +150,12 @@ pub enum DataKey {
     StorageBytes,
     /// Params for the algorithmic fee function (instance-level)
     FeeParams,
+
+    // Staking mechanism keys
+    /// Stores a user's staking record (persistent).
+    Stake(Address),
+    /// Admin-configurable staking parameters (instance-level).
+    StakeConfig,
+    /// Total amount staked across all users (instance-level).
+    TotalStaked,
 }


### PR DESCRIPTION
## Summary

Implements a staking mechanism where users can stake tokens to earn Wrap priority (fee discounts) when minting wraps.

### Changes

- **New module**: src/stake.rs with full staking logic (stake, unstake, withdraw, priority computation, discounted fee)
- **Storage types**: StakeRecord (per-user staking position) and StakeConfig (admin-configurable parameters)
- **DataKey variants**: Stake(Address), StakeConfig, TotalStaked
- **Error codes**: 7 new errors (#15-#21) for staking-specific failure modes
- **Contract entry points**: stake, unstake, withdraw_stake, get_stake, get_stake_priority, total_staked, set_stake_config, get_stake_config, get_discounted_fee
- **Tests**: 17 comprehensive tests in src/stake_test.rs covering happy paths, error cases, priority computation, multi-user scenarios, and event emission
- **Documentation**: Updated STORAGE.md with staking storage layout and priority/fee formulas

### How it works

1. Users call stake(user, amount) to deposit tokens (minimum configurable, default 100)
2. Priority is computed as (amount / min_stake) * priority_multiplier_bps capped at max_priority_bps
3. Fee discount = raw_fee * priority_bps / 10,000
4. Users call unstake(user) to initiate a cooldown (configurable, default 7 days)
5. After cooldown, withdraw_stake(user) completes the withdrawal
6. No priority during active unstaking period

Closes #516