### PR TITLE
docs: add changelog for contract interface changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,41 @@
 # Changelog
 
-## v0.1.0
+## 0.1.0
 
-> Note: The entries below are documentation-focused (no functional changes implied).
+### Contract interface snapshot
 
-### Added
+This release documents the current public Soroban interface for the Stellar Wrap contract and records the client-facing contract changes that should be considered by backend and frontend integrations.
 
-- Initial release of the Stellar Wrap Soroban smart contract.
-- Public contract interface and storage schema documented across `README.md` and `STORAGE.md`.
+#### Current write methods
+
+- `initialize(e, admin, admin_pubkey)`
+- `update_admin(e, new_admin)`
+- `pause(e)` / `unpause(e)`
+- `migrate(e, version)`
+- `mint_wrap(e, user, period, archetype, data_hash, payload_version, signature)`
+
+#### Current read methods
+
+- `get_wrap(e, user, period)`
+- `get_mint_timestamp(e, user, period)`
+- `balance_of(e, user)`
+- `total_wrap_count(e)`
+- `verify_data(e, user, period, data)`
+- `get_latest_wrap(e, user)`
+- `get_wraps(e, user, start, limit)`
+- `get_admin(e)`
+- `health(e)`
+- `name(e)`, `symbol(e)`, `decimals(e)`
+- `migration_version(e)`
+
+### Breaking changes and migration notes
+
+- Mint signatures are now versioned. Clients must sign the canonical payload with the current payload-versioning scheme and pass the `payload_version` argument to `mint_wrap`. Legacy integrations that only prepared signatures for the older layout should update their signer flow before deployment.
+- The documented public interface now includes additional query helpers such as `get_mint_timestamp`, `total_wrap_count`, and `get_wraps`. Consumers that rely on older assumptions about the contract surface should review the current method list before building or updating clients.
+- Wraps remain non-transferable and revoke semantics are not implemented. Frontends and indexers should use contract queries such as `get_wrap`, `balance_of`, and `verify_data` rather than inferring state from events alone.
+
+### Notes for future releases
+
+For every future entry, include a `Migration notes` subsection describing any breaking change and the required updates for client code, backend signers, and indexers.
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Soroban contract for storing non-transferable Stellar Wrap records by wallet and reporting successful wrap mints through events.
 
+## Changelog and client migration notes
+
+The current contract interface for version 0.1.0 is documented in [CHANGELOG.md](CHANGELOG.md). Backend and frontend consumers should review the migration notes there before updating integrations, especially around the versioned mint-signature payload and the expanded query surface.
+
 ## Contract layout
 
 The contract is split into focused modules:


### PR DESCRIPTION
closes #229 

Summary:
I added the changelog documentation for the current contract interface in [CHANGELOG.md] and linked it from [README.md]