### PR TITLE
feat: Adds user opt-out flag

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,4 +18,5 @@ pub enum ContractError {
     Paused = 12,
     ArithmeticOverflow = 13,
     InvalidFeeParams = 14,
+    UserOptedOut = 15,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,31 @@ impl StellarWrapContract {
         queries::decimals(e)
     }
 
+    /// Set the caller's opt-out flag, preventing any future wraps from being
+    /// minted for them. Only the user themselves can call this.
+    pub fn opt_out(e: Env, user: Address) {
+        user.require_auth();
+        let key = crate::storage_types::DataKey::OptOut(user);
+        let ttl = 17280 * 365; // ~1 year in ledgers
+        e.storage().persistent().set(&key, &true);
+        e.storage().persistent().extend_ttl(&key, ttl, ttl);
+    }
+
+    /// Clear the caller's opt-out flag, allowing future wraps to be minted for
+    /// them again. Only the user themselves can call this.
+    pub fn opt_in(e: Env, user: Address) {
+        user.require_auth();
+        let key = crate::storage_types::DataKey::OptOut(user);
+        e.storage().persistent().remove(&key);
+    }
+
+    /// Returns `true` if the user has opted out of future mints.
+    pub fn is_opted_out(e: Env, user: Address) -> bool {
+        e.storage()
+            .persistent()
+            .has(&crate::storage_types::DataKey::OptOut(user))
+    }
+
     pub fn revoke_wrap(e: Env, user: Address, period: u64, reason_hash: BytesN<32>) {
         revoke::revoke_wrap(e, user, period, reason_hash);
     }

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -42,6 +42,15 @@ pub(crate) fn mint_wrap(
 ) {
     crate::admin::require_not_paused(&e);
     user.require_auth();
+
+    // Reject minting for users who have explicitly opted out.
+    if e.storage()
+        .persistent()
+        .has(&DataKey::OptOut(user.clone()))
+    {
+        panic_with_error!(e, ContractError::UserOptedOut);
+    }
+
     validate_period(&e, period);
     validate_payload_version(&e, payload_version);
 

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -118,6 +118,9 @@ pub enum DataKey {
     Symbol,
     /// Emergency pause state flag.
     Paused,
+    /// User-controlled opt-out flag. Present means the user has opted out of
+    /// future mints; absent means minting is allowed.
+    OptOut(Address),
 
     // New instance storage keys for accounting / fee system:
     /// Estimated persistent storage bytes used by this contract (instance-level)

--- a/src/test.rs
+++ b/src/test.rs
@@ -2529,3 +2529,281 @@ fn test_set_alias_hash_requires_auth() {
     let dummy_wasm_hash = BytesN::from_array(&env, &[0xBBu8; 32]);
     client.upgrade(&dummy_wasm_hash);
 }
+
+// ─── Feature #287: User opt-out flag ────────────────────────────────────────
+
+#[cfg(test)]
+mod opt_out_tests {
+    extern crate std;
+
+    use ed25519_dalek::{Signer, SigningKey};
+    use soroban_sdk::{
+        symbol_short,
+        testutils::{Address as _, MockAuth, MockAuthInvoke},
+        Address, BytesN, Env,
+    };
+
+    use crate::{
+        mint::CURRENT_PAYLOAD_VERSION,
+        signature::construct_mint_payload,
+        StellarWrapContract, StellarWrapContractClient,
+    };
+
+    /// Build a valid admin Ed25519 signature for a mint call.
+    fn make_sig(
+        env: &Env,
+        signer: &SigningKey,
+        contract_id: &Address,
+        user: &Address,
+        period: u64,
+        archetype: &soroban_sdk::Symbol,
+        data_hash: &BytesN<32>,
+    ) -> BytesN<64> {
+        let payload = construct_mint_payload(
+            env,
+            contract_id,
+            user,
+            period,
+            archetype,
+            data_hash,
+            CURRENT_PAYLOAD_VERSION,
+        );
+        let mut buf = [0u8; 512];
+        let len = payload.len() as usize;
+        payload.copy_into_slice(&mut buf[..len]);
+        let sig = signer.sign(&buf[..len]);
+        BytesN::from_array(env, &sig.to_bytes())
+    }
+
+    // ── is_opted_out defaults to false ──────────────────────────────────────
+
+    #[test]
+    fn test_is_opted_out_default_false() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+
+        let user = Address::generate(&env);
+        assert!(!client.is_opted_out(&user));
+    }
+
+    // ── opt_out sets the flag ────────────────────────────────────────────────
+
+    #[test]
+    fn test_opt_out_sets_flag() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+        env.mock_all_auths();
+
+        let user = Address::generate(&env);
+        client.opt_out(&user);
+        assert!(client.is_opted_out(&user));
+    }
+
+    // ── opt_in clears the flag ───────────────────────────────────────────────
+
+    #[test]
+    fn test_opt_in_clears_flag() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+        env.mock_all_auths();
+
+        let user = Address::generate(&env);
+        client.opt_out(&user);
+        assert!(client.is_opted_out(&user));
+
+        client.opt_in(&user);
+        assert!(!client.is_opted_out(&user));
+    }
+
+    // ── opted-out user cannot have a wrap minted (error #15) ─────────────────
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #15)")]
+    fn test_opted_out_user_mint_rejected() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+        env.mock_all_auths();
+
+        let user = Address::generate(&env);
+        let archetype = symbol_short!("arch");
+        let hash = BytesN::from_array(&env, &[1u8; 32]);
+        let period = 202501u64;
+
+        client.opt_out(&user);
+
+        let sig = make_sig(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+        client.mint_wrap(&user, &period, &archetype, &hash, &CURRENT_PAYLOAD_VERSION, &sig);
+    }
+
+    // ── after opt-in, minting succeeds again ─────────────────────────────────
+
+    #[test]
+    fn test_opt_in_re_enables_mint() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+        env.mock_all_auths();
+
+        let user = Address::generate(&env);
+        let archetype = symbol_short!("arch");
+        let hash = BytesN::from_array(&env, &[2u8; 32]);
+        let period = 202502u64;
+
+        // Opt out then back in.
+        client.opt_out(&user);
+        client.opt_in(&user);
+        assert!(!client.is_opted_out(&user));
+
+        let sig = make_sig(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+        client.mint_wrap(&user, &period, &archetype, &hash, &CURRENT_PAYLOAD_VERSION, &sig);
+        assert!(client.get_wrap(&user, &period).is_some());
+    }
+
+    // ── opt_out requires the user's own auth ─────────────────────────────────
+
+    #[test]
+    #[should_panic]
+    fn test_opt_out_requires_user_auth() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[8u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+        // No mock_all_auths — auth must be required.
+
+        let user = Address::generate(&env);
+        client.opt_out(&user); // must panic — no auth provided
+    }
+
+    // ── opt_in requires the user's own auth ──────────────────────────────────
+
+    #[test]
+    #[should_panic]
+    fn test_opt_in_requires_user_auth() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[9u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+        // No mock_all_auths — auth must be required.
+
+        let user = Address::generate(&env);
+        client.opt_in(&user); // must panic — no auth provided
+    }
+
+    // ── admin auth alone cannot satisfy opt_out for a different user ─────────
+
+    #[test]
+    #[should_panic]
+    fn test_admin_cannot_opt_out_another_user() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[10u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+
+        // Only mock the admin's auth, not the user's.
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "opt_out",
+                args: soroban_sdk::vec![&env].into(),
+            },
+        }]);
+
+        let user = Address::generate(&env);
+        client.opt_out(&user); // must panic — admin auth != user auth
+    }
+
+    // ── non-opted-out user can mint normally ────────────────────────────────
+
+    #[test]
+    fn test_mint_succeeds_when_not_opted_out() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+        env.mock_all_auths();
+
+        let user = Address::generate(&env);
+        let archetype = symbol_short!("arch");
+        let hash = BytesN::from_array(&env, &[3u8; 32]);
+        let period = 202503u64;
+
+        assert!(!client.is_opted_out(&user));
+
+        let sig = make_sig(&env, &signing_key, &contract_id, &user, period, &archetype, &hash);
+        client.mint_wrap(&user, &period, &archetype, &hash, &CURRENT_PAYLOAD_VERSION, &sig);
+        assert!(client.get_wrap(&user, &period).is_some());
+    }
+
+    // ── multiple opt-out / opt-in cycles are idempotent ─────────────────────
+
+    #[test]
+    fn test_multiple_opt_cycles_are_idempotent() {
+        let env = Env::default();
+        let contract_id = env.register_contract(None, StellarWrapContract);
+        let client = StellarWrapContractClient::new(&env, &contract_id);
+
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+        let admin = Address::generate(&env);
+        client.initialize(&admin, &admin_pubkey);
+        env.mock_all_auths();
+
+        let user = Address::generate(&env);
+
+        // Double opt-out does not change behavior.
+        client.opt_out(&user);
+        client.opt_out(&user);
+        assert!(client.is_opted_out(&user));
+
+        // Double opt-in does not change behavior.
+        client.opt_in(&user);
+        client.opt_in(&user);
+        assert!(!client.is_opted_out(&user));
+    }
+}


### PR DESCRIPTION
## Description

Adds a user-controlled opt-out flag to the Stellar Wrap Registry contract so that users can permanently prevent future wraps from being minted for them. Previously there was no way for a user to signal non-consent  the backend could mint a wrap for any valid address as long as the admin signature checked out. This change gives users sovereign control over their own record without requiring admin involvement.

## Related Issue

Closes #287

## Changes Made

- **`src/storage_types.rs`** — Added `DataKey::OptOut(Address)` variant to the `DataKey` enum. The key is stored in persistent storage; presence means opted-out, absence means minting is allowed.
- **`src/errors.rs`** — Added `ContractError::UserOptedOut = 15` so callers receive a typed, machine-readable error rather than a generic panic.
- **`src/mint.rs`** — Inserted an opt-out guard at the top of `mint_wrap`, after `require_auth` and the pause check, before any signature verification or storage writes. If `DataKey::OptOut(user)` is present, the call aborts with `UserOptedOut`.
- **`src/lib.rs`** — Exposed three new contract entry points:
  - `opt_out(e, user)` — sets the flag; requires `user.require_auth()`.
  - `opt_in(e, user)` — removes the flag; requires `user.require_auth()`.
  - `is_opted_out(e, user) -> bool` — read-only query.

## Testing

Added `mod opt_out_tests` in `src/test.rs` with 8 unit tests:

| Test | What it checks |
|---|---|
| `test_is_opted_out_default_false` | Flag is absent by default for any fresh address |
| `test_opt_out_sets_flag` | `opt_out` stores the flag; `is_opted_out` returns `true` |
| `test_opt_in_clears_flag` | `opt_in` removes the flag; `is_opted_out` returns `false` |
| `test_opted_out_user_mint_rejected` | `mint_wrap` panics with `Error(Contract, #15)` when flag is set |
| `test_opt_in_re_enables_mint` | Opt out then back in — subsequent `mint_wrap` succeeds |
| `test_opt_out_requires_user_auth` | `opt_out` panics when no auth is provided |
| `test_opt_in_requires_user_auth` | `opt_in` panics when no auth is provided |
| `test_admin_cannot_opt_out_another_user` | Admin auth alone cannot satisfy `user.require_auth()` for a different address |
| `test_multiple_opt_cycles_are_idempotent` | Double opt-out and double opt-in leave state consistent |

## Checklist

- [x] Tests added where applicable
- [x] No breaking changes — omitting `opt_out` leaves existing mint behaviour identical to before
- [x] Auth enforcement: only the user themselves can set or clear their own flag; admin has no override
- [x] Error code documented (`UserOptedOut = 15`) in `errors.rs`
- [x] TTL set on the opt-out storage entry (~1 year, consistent with other persistent keys)
