### PR TITLE
feat: add Soroban-RPC indexer pipeline with full test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ Cargo.lock
 Thumbs.db
 test_snapshots/
 mutants.out/
+
+# node_modules
+pipeline/node_modules/

--- a/pipeline/package-lock.json
+++ b/pipeline/package-lock.json
@@ -1,0 +1,2866 @@
+{
+  "name": "stellar-wrap-indexer-pipeline",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "stellar-wrap-indexer-pipeline",
+      "version": "1.0.0",
+      "dependencies": {
+        "@stellar/stellar-sdk": "^13.0.0",
+        "dotenv": "^16.4.0",
+        "sql.js": "^1.10.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.0",
+        "vitest": "^1.3.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.1.0.tgz",
+      "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.1.2",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.3.6",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "sodium-native": "^4.3.3"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.3.0.tgz",
+      "integrity": "sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^13.1.0",
+        "axios": "^1.8.4",
+        "bignumber.js": "^9.3.0",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sodium-native": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
+      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.1.tgz",
+      "integrity": "sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==",
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/pipeline/package.json
+++ b/pipeline/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "stellar-wrap-indexer-pipeline",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Soroban-RPC indexer pipeline for Stellar Wrap contract historical storage data",
+  "scripts": {
+    "start": "ts-node src/index.ts",
+    "backfill": "ts-node src/index.ts --backfill",
+    "reconcile": "ts-node src/index.ts --reconcile-only",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^13.0.0",
+    "dotenv": "^16.4.0",
+    "sql.js": "^1.10.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0",
+    "vitest": "^1.3.0"
+  }
+}

--- a/pipeline/src/__tests__/db.test.ts
+++ b/pipeline/src/__tests__/db.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { IndexerDB } from '../db';
+
+describe('IndexerDB', () => {
+  let db: IndexerDB;
+
+  beforeEach(async () => {
+    db = await IndexerDB.create();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  const contractId = 'CCONTRACT123';
+
+  it('creates tables on initialization', () => {
+    // Verify tables exist by inserting and reading
+    db.insertEvent({
+      id: 'evt-1',
+      contract_id: contractId,
+      event_type: 'mint',
+      ledger_seq: 100,
+      tx_hash: 'tx1',
+      topics_json: '[]',
+      data_json: '{}',
+      failed_call: false,
+    });
+
+    const latest = db.getLatestEventLedger(contractId);
+    expect(latest).toBe(100);
+  });
+
+  it('inserts and retrieves events', () => {
+    db.insertEvent({
+      id: 'evt-1',
+      contract_id: contractId,
+      event_type: 'mint',
+      ledger_seq: 100,
+      tx_hash: 'tx1',
+      topics_json: '[]',
+      data_json: '{}',
+      failed_call: false,
+    });
+
+    db.insertEvent({
+      id: 'evt-2',
+      contract_id: contractId,
+      event_type: 'revoke',
+      ledger_seq: 200,
+      tx_hash: 'tx2',
+      topics_json: '[]',
+      data_json: '{}',
+      failed_call: false,
+    });
+
+    const events = db.getEventsByLedgerRange(contractId, 50, 250);
+    expect(events).toHaveLength(2);
+    expect(events[0].event_type).toBe('mint');
+    expect(events[1].event_type).toBe('revoke');
+  });
+
+  it('ignores duplicate events (INSERT OR IGNORE)', () => {
+    db.insertEvent({
+      id: 'evt-1',
+      contract_id: contractId,
+      event_type: 'mint',
+      ledger_seq: 100,
+      tx_hash: 'tx1',
+      topics_json: '[]',
+      data_json: '{}',
+      failed_call: false,
+    });
+
+    db.insertEvent({
+      id: 'evt-1',
+      contract_id: contractId,
+      event_type: 'mint',
+      ledger_seq: 100,
+      tx_hash: 'tx1',
+      topics_json: '[]',
+      data_json: '{}',
+      failed_call: false,
+    });
+
+    const events = db.getEventsByLedgerRange(contractId, 0, 999);
+    expect(events).toHaveLength(1);
+  });
+
+  it('upserts wrap records', () => {
+    db.upsertWrap({
+      contract_id: contractId,
+      user: 'GUSER1',
+      period: 202501,
+      timestamp: 1000,
+      data_hash: 'ab'.repeat(32),
+      archetype: 'arch',
+      fsm_state: 3,
+      fsm_updated_at: 1000,
+      ledger_seq: 100,
+      tx_hash: 'tx1',
+    });
+
+    expect(db.getWrapCount(contractId)).toBe(1);
+
+    // Upsert same wrap again (update)
+    db.upsertWrap({
+      contract_id: contractId,
+      user: 'GUSER1',
+      period: 202501,
+      timestamp: 2000,
+      data_hash: 'cd'.repeat(32),
+      archetype: 'arch',
+      fsm_state: 4,
+      fsm_updated_at: 2000,
+      ledger_seq: 200,
+      tx_hash: 'tx2',
+    });
+
+    expect(db.getWrapCount(contractId)).toBe(1);
+  });
+
+  it('removes wrap records', () => {
+    db.upsertWrap({
+      contract_id: contractId,
+      user: 'GUSER1',
+      period: 202501,
+      timestamp: 1000,
+      data_hash: 'ab'.repeat(32),
+      archetype: 'arch',
+      fsm_state: 3,
+      fsm_updated_at: 1000,
+      ledger_seq: 100,
+      tx_hash: 'tx1',
+    });
+
+    expect(db.getWrapCount(contractId)).toBe(1);
+
+    db.removeWrap(contractId, 'GUSER1', 202501);
+    expect(db.getWrapCount(contractId)).toBe(0);
+  });
+
+  it('upserts user state', () => {
+    db.upsertUserState({
+      contract_id: contractId,
+      user: 'GUSER1',
+      wrap_count: 5,
+      latest_period: 202505,
+      alias_hash: 'ff'.repeat(32),
+      slash_count: 0,
+      is_slashed: false,
+      periods: [202501, 202502, 202503],
+      ledger_seq: 200,
+    });
+
+    // Update with new data
+    db.upsertUserState({
+      contract_id: contractId,
+      user: 'GUSER1',
+      wrap_count: 6,
+      latest_period: 202506,
+      alias_hash: null,
+      slash_count: 2,
+      is_slashed: true,
+      periods: [202501, 202502, 202503, 202506],
+      ledger_seq: 300,
+    });
+
+    // Re-query via contract state operations indirectly
+    // No direct getter for user state, but we can verify via stats
+    const stats = db.getStats(contractId);
+    expect(stats.total_wraps).toBe(0); // No wraps were upserted in this test
+  });
+
+  it('upserts contract state', () => {
+    db.upsertContractState({
+      contract_id: contractId,
+      admin: 'GADMIN',
+      admin_pubkey: 'aa'.repeat(32),
+      pending_admin: null,
+      migration_version: 1,
+      is_paused: false,
+      total_wrap_count: 10,
+      total_revoked: 2,
+      storage_bytes: 1024,
+      slash_threshold: 5,
+      ledger_seq: 500,
+    });
+
+    const state = db.getContractState(contractId);
+    expect(state).not.toBeNull();
+    expect(state!.admin).toBe('GADMIN');
+    expect(state!.total_wrap_count).toBe(10);
+    expect(state!.slash_threshold).toBe(5);
+
+    // Update
+    db.upsertContractState({
+      contract_id: contractId,
+      admin: 'GADMIN2',
+      admin_pubkey: 'bb'.repeat(32),
+      pending_admin: null,
+      migration_version: 2,
+      is_paused: true,
+      total_wrap_count: 20,
+      total_revoked: 3,
+      storage_bytes: 2048,
+      slash_threshold: 3,
+      ledger_seq: 600,
+    });
+
+    const updated = db.getContractState(contractId);
+    expect(updated!.admin).toBe('GADMIN2');
+    expect(updated!.is_paused).toBe(1);
+    expect(updated!.slash_threshold).toBe(3);
+  });
+
+  it('manages ledger cursor', () => {
+    const cursorId = `cursor:${contractId}`;
+
+    // No cursor initially
+    const initial = db.getCursor(cursorId);
+    expect(initial).toBeNull();
+
+    // Create cursor
+    db.upsertCursor(cursorId, contractId, 100, 100);
+    const cursor = db.getCursor(cursorId);
+    expect(cursor).not.toBeNull();
+    expect(cursor!.last_processed_ledger).toBe(100);
+
+    // Update cursor
+    db.upsertCursor(cursorId, contractId, 500, 500);
+    const updated = db.getCursor(cursorId);
+    expect(updated!.last_processed_ledger).toBe(500);
+  });
+
+  it('returns stats', () => {
+    db.upsertWrap({
+      contract_id: contractId,
+      user: 'GUSER1',
+      period: 202501,
+      timestamp: 1000,
+      data_hash: 'ab'.repeat(32),
+      archetype: 'arch',
+      fsm_state: 3,
+      fsm_updated_at: 1000,
+      ledger_seq: 100,
+      tx_hash: 'tx1',
+    });
+
+    db.insertEvent({
+      id: 'evt-1',
+      contract_id: contractId,
+      event_type: 'mint',
+      ledger_seq: 100,
+      tx_hash: 'tx1',
+      topics_json: '[]',
+      data_json: '{}',
+      failed_call: false,
+    });
+
+    const stats = db.getStats(contractId);
+    expect(stats.total_events).toBe(1);
+    expect(stats.total_wraps).toBe(1);
+    expect(stats.last_indexed_ledger).toBe(100);
+  });
+});

--- a/pipeline/src/__tests__/decoder.test.ts
+++ b/pipeline/src/__tests__/decoder.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import { xdr, Address } from '@stellar/stellar-sdk';
+import { decodeDataKey, decodeStorageValue, decodeEventTopic, decodeEventData } from '../decoder';
+import { DataKeyVariant } from '../types';
+
+function makeSingletonKey(name: string): xdr.ScVal {
+  return xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(name)]);
+}
+
+function makeAddressScVal(addr: string): xdr.ScVal {
+  return Address.fromString(addr).toScVal();
+}
+
+function makeU64ScVal(val: number): xdr.ScVal {
+  return xdr.ScVal.scvU64(new xdr.Uint64(val));
+}
+
+describe('decodeDataKey', () => {
+  it('decodes Admin singleton key', () => {
+    const result = decodeDataKey(makeSingletonKey('Admin'));
+    expect(result.variant).toBe(DataKeyVariant.Admin);
+  });
+
+  it('decodes AdminPubKey singleton key', () => {
+    const result = decodeDataKey(makeSingletonKey('AdminPubKey'));
+    expect(result.variant).toBe(DataKeyVariant.AdminPubKey);
+  });
+
+  it('decodes Wrap key with address and period', () => {
+    const userAddr = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const key = xdr.ScVal.scvVec([
+      xdr.ScVal.scvSymbol('Wrap'),
+      makeAddressScVal(userAddr),
+      makeU64ScVal(202501),
+    ]);
+    const result = decodeDataKey(key);
+    expect(result.variant).toBe(DataKeyVariant.Wrap);
+    if (result.variant === DataKeyVariant.Wrap) {
+      expect(result.user).toBe(userAddr);
+      expect(result.period).toBe(202501);
+    }
+  });
+
+  it('decodes WrapCount key with address', () => {
+    const userAddr = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const key = xdr.ScVal.scvVec([
+      xdr.ScVal.scvSymbol('WrapCount'),
+      makeAddressScVal(userAddr),
+    ]);
+    const result = decodeDataKey(key);
+    expect(result.variant).toBe(DataKeyVariant.WrapCount);
+    if (result.variant === DataKeyVariant.WrapCount) {
+      expect(result.user).toBe(userAddr);
+    }
+  });
+
+  it('decodes SlashCount key with address', () => {
+    const userAddr = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const key = xdr.ScVal.scvVec([
+      xdr.ScVal.scvSymbol('SlashCount'),
+      makeAddressScVal(userAddr),
+    ]);
+    const result = decodeDataKey(key);
+    expect(result.variant).toBe(DataKeyVariant.SlashCount);
+    if (result.variant === DataKeyVariant.SlashCount) {
+      expect(result.user).toBe(userAddr);
+    }
+  });
+
+  it('decodes Slashed key with address', () => {
+    const userAddr = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const key = xdr.ScVal.scvVec([
+      xdr.ScVal.scvSymbol('Slashed'),
+      makeAddressScVal(userAddr),
+    ]);
+    const result = decodeDataKey(key);
+    expect(result.variant).toBe(DataKeyVariant.Slashed);
+    if (result.variant === DataKeyVariant.Slashed) {
+      expect(result.user).toBe(userAddr);
+    }
+  });
+
+  it('decodes SlashThreshold singleton key', () => {
+    const result = decodeDataKey(makeSingletonKey('SlashThreshold'));
+    expect(result.variant).toBe(DataKeyVariant.SlashThreshold);
+  });
+
+  it('decodes TotalWrapCount key', () => {
+    const result = decodeDataKey(makeSingletonKey('TotalWrapCount'));
+    expect(result.variant).toBe(DataKeyVariant.TotalWrapCount);
+  });
+
+  it('decodes FeeParams key', () => {
+    const result = decodeDataKey(makeSingletonKey('FeeParams'));
+    expect(result.variant).toBe(DataKeyVariant.FeeParams);
+  });
+
+  it('throws on unknown variant', () => {
+    expect(() => {
+      decodeDataKey(makeSingletonKey('NonExistent'));
+    }).toThrow();
+  });
+
+  it('throws on empty vec', () => {
+    expect(() => {
+      decodeDataKey(xdr.ScVal.scvVec([]));
+    }).toThrow();
+  });
+});
+
+describe('decodeStorageValue', () => {
+  it('decodes Admin address value', () => {
+    const addr = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const key = { variant: DataKeyVariant.Admin as const };
+    const val = makeAddressScVal(addr);
+    const result = decodeStorageValue(key, val);
+    expect(result.type).toBe('address');
+    if (result.type === 'address') {
+      expect(result.value).toBe(addr);
+    }
+  });
+
+  it('decodes bool value', () => {
+    const key = { variant: DataKeyVariant.Paused as const };
+    const val = xdr.ScVal.scvBool(true);
+    const result = decodeStorageValue(key, val);
+    expect(result.type).toBe('bool');
+    if (result.type === 'bool') {
+      expect(result.value).toBe(true);
+    }
+  });
+
+  it('decodes u32 value', () => {
+    const key = { variant: DataKeyVariant.SlashThreshold as const };
+    const val = xdr.ScVal.scvU32(5);
+    const result = decodeStorageValue(key, val);
+    expect(result.type).toBe('u32');
+    if (result.type === 'u32') {
+      expect(result.value).toBe(5);
+    }
+  });
+
+  it('decodes u64 value', () => {
+    const key = { variant: DataKeyVariant.StorageBytes as const };
+    const val = makeU64ScVal(999);
+    const result = decodeStorageValue(key, val);
+    expect(result.type).toBe('u64');
+    if (result.type === 'u64') {
+      expect(result.value).toBe(999);
+    }
+  });
+
+  it('decodes bytes32 value', () => {
+    const key = { variant: DataKeyVariant.AdminPubKey as const };
+    const buf = Buffer.alloc(32, 0xab);
+    const val = xdr.ScVal.scvBytes(buf);
+    const result = decodeStorageValue(key, val);
+    expect(result.type).toBe('bytes32');
+    if (result.type === 'bytes32') {
+      expect(result.value).toBe('ab'.repeat(32));
+    }
+  });
+});
+
+describe('decodeEventTopic', () => {
+  it('decodes symbol topic', () => {
+    const val = xdr.ScVal.scvSymbol('mint');
+    const result = decodeEventTopic(val);
+    expect(result.type).toBe('symbol');
+    expect(result.value).toBe('mint');
+  });
+
+  it('decodes address topic', () => {
+    const addr = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const val = makeAddressScVal(addr);
+    const result = decodeEventTopic(val);
+    expect(result.type).toBe('address');
+    expect(result.value).toBe(addr);
+  });
+
+  it('decodes u64 topic', () => {
+    const val = makeU64ScVal(202501);
+    const result = decodeEventTopic(val);
+    expect(result.type).toBe('u64');
+    expect(result.value).toBe(202501);
+  });
+
+  it('decodes bool topic', () => {
+    const val = xdr.ScVal.scvBool(true);
+    const result = decodeEventTopic(val);
+    expect(result.type).toBe('bool');
+    expect(result.value).toBe(true);
+  });
+});
+
+describe('decodeEventData', () => {
+  it('decodes symbol data', () => {
+    const val = xdr.ScVal.scvSymbol('arch');
+    const result = decodeEventData(val);
+    expect(result.type).toBe('string');
+    expect(result.value).toBe('arch');
+  });
+
+  it('decodes address data', () => {
+    const addr = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const val = makeAddressScVal(addr);
+    const result = decodeEventData(val);
+    expect(result.type).toBe('address');
+    expect(result.value).toBe(addr);
+  });
+
+  it('decodes bytes data', () => {
+    const buf = Buffer.alloc(32, 0x01);
+    const val = xdr.ScVal.scvBytes(buf);
+    const result = decodeEventData(val);
+    expect(result.type).toBe('bytes');
+    expect(result.value).toBe('01'.repeat(32));
+  });
+});

--- a/pipeline/src/__tests__/processor.test.ts
+++ b/pipeline/src/__tests__/processor.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyEvent,
+  createEmptyState,
+  applyEventToState,
+  applyStorageEntryToState,
+} from '../processor';
+import { DataKeyVariant } from '../types';
+import type { ContractEvent, StorageEntry } from '../types';
+
+function makeMockEvent(overrides: Partial<ContractEvent> = {}): ContractEvent {
+  return {
+    id: 'test-event-1',
+    contract_id: 'CCXJKVHD5L3M5X7H3YZJ5Y5Y5Y5Y5Y5Y5Y5Y5Y5Y5Y5Y5Y5Y5Y5Y5Y5',
+    ledger: 100,
+    ledger_close_at: null,
+    tx_hash: 'abc123',
+    topics: [],
+    data: { type: 'string', value: '' },
+    failed_call: false,
+    ...overrides,
+  };
+}
+
+describe('classifyEvent', () => {
+  it('classifies mint event', () => {
+    const event = makeMockEvent({
+      topics: [
+        { type: 'symbol', value: 'mint' },
+        { type: 'address', value: 'GUSER1' },
+        { type: 'u64', value: 202501 },
+      ],
+      data: { type: 'string', value: 'arch' },
+    });
+    const typed = classifyEvent(event);
+    expect(typed.event_type).toBe('mint');
+    expect(typed.parsed.user).toBe('GUSER1');
+    expect(typed.parsed.period).toBe(202501);
+    expect(typed.parsed.archetype).toBe('arch');
+  });
+
+  it('classifies revoke event', () => {
+    const event = makeMockEvent({
+      topics: [
+        { type: 'symbol', value: 'revoke' },
+        { type: 'address', value: 'GUSER1' },
+        { type: 'u64', value: 202501 },
+      ],
+      data: { type: 'bytes', value: 'ab'.repeat(32) },
+    });
+    const typed = classifyEvent(event);
+    expect(typed.event_type).toBe('revoke');
+    expect(typed.parsed.user).toBe('GUSER1');
+    expect(typed.parsed.period).toBe(202501);
+    expect(typed.parsed.reason_hash).toBe('ab'.repeat(32));
+  });
+
+  it('classifies transition event', () => {
+    const event = makeMockEvent({
+      topics: [
+        { type: 'symbol', value: 'trans' },
+        { type: 'address', value: 'GUSER1' },
+        { type: 'u64', value: 202501 },
+      ],
+      data: { type: 'u64', value: 4 },
+    });
+    const typed = classifyEvent(event);
+    expect(typed.event_type).toBe('transition');
+    expect(typed.parsed.next_state).toBe(4);
+  });
+
+  it('classifies init event', () => {
+    const event = makeMockEvent({
+      topics: [
+        { type: 'symbol', value: 'init' },
+        { type: 'address', value: 'GADMIN' },
+      ],
+    });
+    const typed = classifyEvent(event);
+    expect(typed.event_type).toBe('init');
+    expect(typed.parsed.admin).toBe('GADMIN');
+  });
+
+  it('classifies pause event', () => {
+    const event = makeMockEvent({
+      topics: [{ type: 'symbol', value: 'pause' }],
+      data: { type: 'bool', value: true },
+    });
+    const typed = classifyEvent(event);
+    expect(typed.event_type).toBe('pause');
+    expect(typed.parsed.paused).toBe(true);
+  });
+
+  it('classifies slash report event', () => {
+    const event = makeMockEvent({
+      topics: [
+        { type: 'symbol', value: 'slash' },
+        { type: 'symbol', value: 'report' },
+      ],
+      data: { type: 'string', value: '["GUSER1",3]' },
+    });
+    const typed = classifyEvent(event);
+    expect(typed.event_type).toBe('slash_report');
+  });
+
+  it('classifies slash clear event', () => {
+    const event = makeMockEvent({
+      topics: [
+        { type: 'symbol', value: 'slash' },
+        { type: 'symbol', value: 'clear' },
+      ],
+      data: { type: 'address', value: 'GUSER1' },
+    });
+    const typed = classifyEvent(event);
+    expect(typed.event_type).toBe('slash_clear');
+    expect(typed.parsed.user).toBe('GUSER1');
+  });
+
+  it('classifies slash threshold event', () => {
+    const event = makeMockEvent({
+      topics: [
+        { type: 'symbol', value: 'slash' },
+        { type: 'symbol', value: 'thresh' },
+      ],
+      data: { type: 'u32', value: 5 },
+    });
+    const typed = classifyEvent(event);
+    expect(typed.event_type).toBe('slash_threshold');
+    expect(typed.parsed.threshold).toBe(5);
+  });
+
+  it('returns unknown for unrecognized events', () => {
+    const event = makeMockEvent({
+      topics: [{ type: 'symbol', value: 'unknown_event' }],
+    });
+    const typed = classifyEvent(event);
+    expect(typed.event_type).toBe('unknown');
+  });
+});
+
+describe('createEmptyState', () => {
+  it('creates an empty state with defaults', () => {
+    const state = createEmptyState('CCONTRACT', 0);
+    expect(state.contract_id).toBe('CCONTRACT');
+    expect(state.totalWrapCount).toBe(0);
+    expect(state.totalRevoked).toBe(0);
+    expect(state.slashThreshold).toBe(3);
+    expect(state.admin).toBeNull();
+    expect(state.wraps.size).toBe(0);
+    expect(state.userCounts.size).toBe(0);
+  });
+});
+
+describe('applyEventToState', () => {
+  it('applies mint event to state', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+    const event = {
+      raw: makeMockEvent({ ledger: 100 }),
+      event_type: 'mint' as const,
+      parsed: { user: 'GUSER1', period: 202501, archetype: 'arch' },
+    };
+
+    applyEventToState(state, event);
+
+    expect(state.totalWrapCount).toBe(1);
+    expect(state.userCounts.get('GUSER1')).toBe(1);
+    expect(state.userLatestPeriods.get('GUSER1')).toBe(202501);
+    expect(state.wraps.has('GUSER1')).toBe(true);
+    expect(state.wraps.get('GUSER1')?.has(202501)).toBe(true);
+  });
+
+  it('applies revoke event to state', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+
+    // First mint, then revoke
+    applyEventToState(state, {
+      raw: makeMockEvent({ ledger: 100 }),
+      event_type: 'mint',
+      parsed: { user: 'GUSER1', period: 202501, archetype: 'arch' },
+    });
+
+    applyEventToState(state, {
+      raw: makeMockEvent({ ledger: 101 }),
+      event_type: 'revoke',
+      parsed: { user: 'GUSER1', period: 202501, reason_hash: '' },
+    });
+
+    expect(state.totalWrapCount).toBe(1);
+    expect(state.userCounts.get('GUSER1')).toBe(0);
+    expect(state.totalRevoked).toBe(1);
+    expect(state.wraps.has('GUSER1')).toBe(false);
+  });
+
+  it('applies pause event to state', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+    applyEventToState(state, {
+      raw: makeMockEvent({ ledger: 100 }),
+      event_type: 'pause',
+      parsed: { paused: true },
+    });
+    expect(state.paused).toBe(true);
+  });
+
+  it('applies slash report and clear events', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+
+    applyEventToState(state, {
+      raw: makeMockEvent({ ledger: 100 }),
+      event_type: 'slash_report',
+      parsed: { user: 'GUSER1', count: 3 },
+    });
+
+    expect(state.userSlashCounts.get('GUSER1')).toBe(3);
+
+    applyEventToState(state, {
+      raw: makeMockEvent({ ledger: 101 }),
+      event_type: 'slash_clear',
+      parsed: { user: 'GUSER1' },
+    });
+
+    expect(state.userSlashCounts.has('GUSER1')).toBe(false);
+    expect(state.userSlashed.has('GUSER1')).toBe(false);
+  });
+
+  it('applies slash threshold event', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+    applyEventToState(state, {
+      raw: makeMockEvent({ ledger: 100 }),
+      event_type: 'slash_threshold',
+      parsed: { threshold: 10 },
+    });
+    expect(state.slashThreshold).toBe(10);
+  });
+
+  it('applies init event to state', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+    applyEventToState(state, {
+      raw: makeMockEvent({ ledger: 100 }),
+      event_type: 'init',
+      parsed: { admin: 'GADMIN' },
+    });
+    expect(state.admin).toBe('GADMIN');
+  });
+});
+
+describe('applyStorageEntryToState', () => {
+  it('applies Admin storage entry', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+    applyStorageEntryToState(state, {
+      key: { variant: DataKeyVariant.Admin },
+      value: { type: 'address', value: 'GADMIN' },
+      ledger: 100,
+      durability: 'instance',
+    });
+    expect(state.admin).toBe('GADMIN');
+  });
+
+  it('applies Wrap storage entry', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+    const wrapRecord = {
+      timestamp: 1000,
+      data_hash: 'ab'.repeat(32),
+      archetype: 'arch',
+      period: 202501,
+      fsm: { state: 3 as const, updated_at: 1000 },
+    };
+
+    applyStorageEntryToState(state, {
+      key: { variant: DataKeyVariant.Wrap, user: 'GUSER1', period: 202501 },
+      value: { type: 'wrap_record', value: wrapRecord },
+      ledger: 100,
+      durability: 'persistent',
+    });
+
+    expect(state.wraps.has('GUSER1')).toBe(true);
+    expect(state.wraps.get('GUSER1')?.has(202501)).toBe(true);
+  });
+
+  it('applies SlashCount storage entry', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+    applyStorageEntryToState(state, {
+      key: { variant: DataKeyVariant.SlashCount, user: 'GUSER1' },
+      value: { type: 'u32', value: 3 },
+      ledger: 100,
+      durability: 'persistent',
+    });
+    expect(state.userSlashCounts.get('GUSER1')).toBe(3);
+  });
+
+  it('applies Slashed storage entry', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+    applyStorageEntryToState(state, {
+      key: { variant: DataKeyVariant.Slashed, user: 'GUSER1' },
+      value: { type: 'bool', value: true },
+      ledger: 100,
+      durability: 'persistent',
+    });
+    expect(state.userSlashed.get('GUSER1')).toBe(true);
+  });
+
+  it('applies SlashThreshold storage entry', () => {
+    const state = createEmptyState('CCONTRACT', 100);
+    applyStorageEntryToState(state, {
+      key: { variant: DataKeyVariant.SlashThreshold },
+      value: { type: 'u32', value: 10 },
+      ledger: 100,
+      durability: 'instance',
+    });
+    expect(state.slashThreshold).toBe(10);
+  });
+});

--- a/pipeline/src/__tests__/reconciler.test.ts
+++ b/pipeline/src/__tests__/reconciler.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { IndexerDB } from '../db';
+import { reconcile } from '../reconciler';
+import { DataKeyVariant } from '../types';
+
+function mockFetcher(entries: any[]): any {
+  return {
+    fetchStorageEntries: async () => entries,
+  };
+}
+
+describe('reconcile', () => {
+  let db: IndexerDB;
+
+  beforeEach(async () => {
+    db = await IndexerDB.create();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  const contractId = 'CCONTRACT';
+
+  const defaultState = {
+    contract_id: contractId,
+    admin: null,
+    admin_pubkey: null,
+    pending_admin: null,
+    migration_version: 0,
+    is_paused: false,
+    total_wrap_count: 0,
+    total_revoked: 0,
+    storage_bytes: 0,
+    slash_threshold: 3,
+  };
+
+  it('reports consistent when indexed data matches on-chain state', async () => {
+    db.upsertContractState({ ...defaultState, ledger_seq: 100, admin: 'GADMIN' });
+
+    const fetcher = mockFetcher([
+      {
+        key: { variant: DataKeyVariant.Admin },
+        value: { type: 'address', value: 'GADMIN' },
+        ledger: 100,
+        durability: 'instance',
+      },
+    ]);
+
+    const report = await reconcile(db, fetcher, contractId);
+    expect(report.mismatches).toHaveLength(0);
+    expect(report.is_consistent).toBe(true);
+  });
+
+  it('catches admin mismatch', async () => {
+    db.upsertContractState({ ...defaultState, ledger_seq: 100, admin: 'GADMIN_OLD' });
+
+    const fetcher = mockFetcher([
+      {
+        key: { variant: DataKeyVariant.Admin },
+        value: { type: 'address', value: 'GADMIN_NEW' },
+        ledger: 200,
+        durability: 'instance',
+      },
+    ]);
+
+    const report = await reconcile(db, fetcher, contractId);
+    expect(report.is_consistent).toBe(false);
+    expect(report.mismatches.some((m) => m.startsWith('admin'))).toBe(true);
+  });
+
+  it('catches paused mismatch', async () => {
+    db.upsertContractState({ ...defaultState, ledger_seq: 100, is_paused: false });
+
+    const fetcher = mockFetcher([
+      {
+        key: { variant: DataKeyVariant.Admin },
+        value: { type: 'address', value: null },
+        ledger: 100,
+        durability: 'instance',
+      },
+      {
+        key: { variant: DataKeyVariant.Paused },
+        value: { type: 'bool', value: true },
+        ledger: 500,
+        durability: 'instance',
+      },
+    ]);
+
+    const report = await reconcile(db, fetcher, contractId);
+    expect(report.is_consistent).toBe(false);
+    expect(report.mismatches.some((m) => m.startsWith('is_paused'))).toBe(true);
+  });
+
+  it('handles no indexed state (empty DB) - skips comparison', async () => {
+    const fetcher = mockFetcher([
+      {
+        key: { variant: DataKeyVariant.Admin },
+        value: { type: 'address', value: 'GADMIN' },
+        ledger: 100,
+        durability: 'instance',
+      },
+    ]);
+
+    const report = await reconcile(db, fetcher, contractId);
+    // When no indexed state exists, comparisons are skipped -> no mismatches
+    expect(report.mismatches).toHaveLength(0);
+    expect(report.is_consistent).toBe(true);
+    expect(report.indexed.total_wraps).toBe(0);
+  });
+});

--- a/pipeline/src/backfill.ts
+++ b/pipeline/src/backfill.ts
@@ -1,0 +1,74 @@
+import { SorobanFetcher } from './fetcher';
+import { IndexerDB } from './db';
+import { processEventBatch, createEmptyState } from './processor';
+import type { DerivedState } from './types';
+
+export interface BackfillOptions {
+  fetcher: SorobanFetcher;
+  db: IndexerDB;
+  contractId: string;
+  startLedger: number;
+  endLedger?: number;
+  onProgress?: (processed: number, currentLedger: number) => void;
+}
+
+/**
+ * Backfill historical events for a contract from startLedger to endLedger
+ * (or latest ledger if endLedger is not specified).
+ *
+ * This processes events in pages and incrementally builds the derived state.
+ */
+export async function backfillEvents(opts: BackfillOptions): Promise<{
+  processed: number;
+  finalLedger: number;
+  state: DerivedState;
+}> {
+  const { fetcher, db, contractId, startLedger, onProgress } = opts;
+  const endLedger = opts.endLedger ?? (await fetcher.getLatestLedger());
+
+  let currentLedger = startLedger;
+  let totalProcessed = 0;
+  const state = createEmptyState(contractId, startLedger);
+
+  console.log(`Backfilling events from ledger ${startLedger} to ${endLedger}...`);
+
+  while (currentLedger <= endLedger) {
+    try {
+      const { events, latestLedger } = await fetcher.fetchEvents(currentLedger);
+
+      if (events.length > 0) {
+        processEventBatch(db, state, events);
+        totalProcessed += events.length;
+      }
+
+      const nextLedger = latestLedger > 0 ? latestLedger + 1 : currentLedger + 100;
+
+      if (onProgress) {
+        onProgress(totalProcessed, currentLedger);
+      }
+
+      // Update cursor
+      db.upsertCursor(
+        `cursor:${contractId}`,
+        contractId,
+        latestLedger > 0 ? latestLedger : currentLedger,
+        latestLedger > 0 ? latestLedger : currentLedger,
+      );
+
+      currentLedger = nextLedger;
+
+    } catch (err) {
+      console.error(`Error at ledger ${currentLedger}:`, err);
+      // Wait and retry
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+
+  console.log(`Backfill complete. Processed ${totalProcessed} events.`);
+
+  return {
+    processed: totalProcessed,
+    finalLedger: endLedger,
+    state,
+  };
+}

--- a/pipeline/src/config.ts
+++ b/pipeline/src/config.ts
@@ -1,0 +1,26 @@
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+import type { IndexerConfig } from './types';
+
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+
+export function loadConfig(): IndexerConfig {
+  const contractId = process.env.CONTRACT_ID || '';
+  if (!contractId) {
+    throw new Error(
+      'CONTRACT_ID environment variable is required. ' +
+      'Set it in pipeline/.env or export CONTRACT_ID=...'
+    );
+  }
+
+  return {
+    rpc_url: process.env.RPC_URL || 'https://soroban-testnet.stellar.org',
+    contract_id: contractId,
+    db_path: process.env.DB_PATH || path.resolve(__dirname, '../indexer.db'),
+    poll_interval_ms: parseInt(process.env.POLL_INTERVAL_MS || '5000', 10),
+    event_page_size: parseInt(process.env.EVENT_PAGE_SIZE || '100', 10),
+    start_ledger: parseInt(process.env.START_LEDGER || '1', 10),
+    backfill: process.argv.includes('--backfill'),
+    reconcile_only: process.argv.includes('--reconcile-only'),
+  };
+}

--- a/pipeline/src/db.ts
+++ b/pipeline/src/db.ts
@@ -1,0 +1,393 @@
+import initSqlJs, { SqlJsStatic, Database as SqlJsDatabase } from 'sql.js';
+import type {
+  EventRow,
+  ContractStateRow,
+  LedgerCursorRow,
+  StorageEntry,
+} from './types';
+
+export class IndexerDB {
+  private db: SqlJsDatabase;
+
+  constructor(db: SqlJsDatabase) {
+    this.db = db;
+    this.db.run('PRAGMA foreign_keys = ON');
+    this.migrate();
+  }
+
+  static async create(dbPath?: string): Promise<IndexerDB> {
+    const SQL: SqlJsStatic = await initSqlJs();
+    let db: SqlJsDatabase;
+    if (dbPath) {
+      const fs = await import('fs');
+      try {
+        const buffer = fs.readFileSync(dbPath);
+        db = new SQL.Database(buffer);
+      } catch {
+        db = new SQL.Database();
+      }
+    } else {
+      db = new SQL.Database();
+    }
+    return new IndexerDB(db);
+  }
+
+  private migrate(): void {
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS contract_events (
+        id TEXT PRIMARY KEY,
+        contract_id TEXT NOT NULL,
+        event_type TEXT NOT NULL,
+        ledger_seq INTEGER NOT NULL,
+        tx_hash TEXT NOT NULL,
+        topics_json TEXT NOT NULL,
+        data_json TEXT NOT NULL,
+        failed_call INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_events_contract_ledger
+      ON contract_events(contract_id, ledger_seq)`);
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_events_type
+      ON contract_events(event_type)`);
+
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS wrap_records (
+        contract_id TEXT NOT NULL,
+        user TEXT NOT NULL,
+        period INTEGER NOT NULL,
+        timestamp INTEGER NOT NULL,
+        data_hash TEXT NOT NULL,
+        archetype TEXT NOT NULL,
+        fsm_state INTEGER NOT NULL,
+        fsm_updated_at INTEGER NOT NULL,
+        ledger_seq INTEGER NOT NULL,
+        tx_hash TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (contract_id, user, period)
+      )
+    `);
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_wraps_user
+      ON wrap_records(contract_id, user)`);
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_wraps_period
+      ON wrap_records(contract_id, period)`);
+
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS user_state (
+        contract_id TEXT NOT NULL,
+        user TEXT NOT NULL,
+        wrap_count INTEGER NOT NULL DEFAULT 0,
+        latest_period INTEGER,
+        alias_hash TEXT,
+        slash_count INTEGER NOT NULL DEFAULT 0,
+        is_slashed INTEGER NOT NULL DEFAULT 0,
+        periods_json TEXT NOT NULL DEFAULT '[]',
+        ledger_seq INTEGER NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (contract_id, user)
+      )
+    `);
+
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS contract_state (
+        contract_id TEXT PRIMARY KEY,
+        admin TEXT,
+        admin_pubkey TEXT,
+        pending_admin TEXT,
+        migration_version INTEGER NOT NULL DEFAULT 0,
+        is_paused INTEGER NOT NULL DEFAULT 0,
+        total_wrap_count INTEGER NOT NULL DEFAULT 0,
+        total_revoked INTEGER NOT NULL DEFAULT 0,
+        storage_bytes INTEGER NOT NULL DEFAULT 0,
+        slash_threshold INTEGER NOT NULL DEFAULT 3,
+        ledger_seq INTEGER NOT NULL,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS storage_snapshots (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        contract_id TEXT NOT NULL,
+        ledger_seq INTEGER NOT NULL,
+        key_variant TEXT NOT NULL,
+        key_json TEXT NOT NULL,
+        value_type TEXT NOT NULL,
+        value_json TEXT NOT NULL,
+        durability TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_snapshots_ledger
+      ON storage_snapshots(contract_id, ledger_seq)`);
+
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS ledger_cursor (
+        id TEXT PRIMARY KEY,
+        contract_id TEXT NOT NULL,
+        last_processed_ledger INTEGER NOT NULL DEFAULT 0,
+        last_event_ledger INTEGER NOT NULL DEFAULT 0,
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )
+    `);
+  }
+
+  private exec(sql: string, params: unknown[] = []): void {
+    this.db.run(sql, params);
+  }
+
+  private fetchOne(sql: string, params: unknown[] = []): Record<string, unknown> | null {
+    const stmt = this.db.prepare(sql);
+    if (params.length > 0) stmt.bind(params);
+    let row: Record<string, unknown> | null = null;
+    if (stmt.step()) {
+      row = stmt.getAsObject();
+    }
+    stmt.free();
+    return row;
+  }
+
+  private fetchAll(sql: string, params: unknown[] = []): Record<string, unknown>[] {
+    const stmt = this.db.prepare(sql);
+    if (params.length > 0) stmt.bind(params);
+    const rows: Record<string, unknown>[] = [];
+    while (stmt.step()) {
+      rows.push(stmt.getAsObject());
+    }
+    stmt.free();
+    return rows;
+  }
+
+  // ─── Events ─────────────────────────────────────────────────────────
+
+  insertEvent(event: {
+    id: string;
+    contract_id: string;
+    event_type: string;
+    ledger_seq: number;
+    tx_hash: string;
+    topics_json: string;
+    data_json: string;
+    failed_call: boolean;
+  }): void {
+    this.exec(
+      `INSERT OR IGNORE INTO contract_events
+        (id, contract_id, event_type, ledger_seq, tx_hash, topics_json, data_json, failed_call)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [event.id, event.contract_id, event.event_type, event.ledger_seq, event.tx_hash, event.topics_json, event.data_json, event.failed_call ? 1 : 0],
+    );
+  }
+
+  getEventsByLedgerRange(
+    contractId: string,
+    startLedger: number,
+    endLedger: number,
+    limit: number = 1000,
+  ): EventRow[] {
+    return this.fetchAll(
+      `SELECT * FROM contract_events
+       WHERE contract_id = ? AND ledger_seq >= ? AND ledger_seq <= ?
+       ORDER BY ledger_seq ASC
+       LIMIT ?`,
+      [contractId, startLedger, endLedger, limit],
+    ) as unknown as EventRow[];
+  }
+
+  getLatestEventLedger(contractId: string): number | null {
+    const row = this.fetchOne(
+      `SELECT MAX(ledger_seq) as max_ledger FROM contract_events WHERE contract_id = ?`,
+      [contractId],
+    ) as { max_ledger: number | null } | null;
+    return row?.max_ledger ?? null;
+  }
+
+  // ─── Wrap Records ───────────────────────────────────────────────────
+
+  upsertWrap(record: {
+    contract_id: string;
+    user: string;
+    period: number;
+    timestamp: number;
+    data_hash: string;
+    archetype: string;
+    fsm_state: number;
+    fsm_updated_at: number;
+    ledger_seq: number;
+    tx_hash: string;
+  }): void {
+    this.exec(
+      `INSERT INTO wrap_records
+        (contract_id, user, period, timestamp, data_hash, archetype, fsm_state, fsm_updated_at, ledger_seq, tx_hash)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(contract_id, user, period) DO UPDATE SET
+        timestamp = excluded.timestamp,
+        data_hash = excluded.data_hash,
+        archetype = excluded.archetype,
+        fsm_state = excluded.fsm_state,
+        fsm_updated_at = excluded.fsm_updated_at,
+        ledger_seq = excluded.ledger_seq,
+        tx_hash = excluded.tx_hash,
+        updated_at = datetime('now')`,
+      [record.contract_id, record.user, record.period, record.timestamp, record.data_hash, record.archetype, record.fsm_state, record.fsm_updated_at, record.ledger_seq, record.tx_hash],
+    );
+  }
+
+  removeWrap(contractId: string, user: string, period: number): void {
+    this.exec(
+      `DELETE FROM wrap_records WHERE contract_id = ? AND user = ? AND period = ?`,
+      [contractId, user, period],
+    );
+  }
+
+  getWrapCount(contractId: string): number {
+    const row = this.fetchOne(
+      `SELECT COUNT(*) as count FROM wrap_records WHERE contract_id = ?`,
+      [contractId],
+    ) as { count: number };
+    return row.count;
+  }
+
+  // ─── User State ─────────────────────────────────────────────────────
+
+  upsertUserState(state: {
+    contract_id: string;
+    user: string;
+    wrap_count: number;
+    latest_period: number | null;
+    alias_hash: string | null;
+    slash_count: number;
+    is_slashed: boolean;
+    periods: number[];
+    ledger_seq: number;
+  }): void {
+    this.exec(
+      `INSERT INTO user_state
+        (contract_id, user, wrap_count, latest_period, alias_hash, slash_count, is_slashed, periods_json, ledger_seq)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(contract_id, user) DO UPDATE SET
+        wrap_count = excluded.wrap_count,
+        latest_period = excluded.latest_period,
+        alias_hash = excluded.alias_hash,
+        slash_count = excluded.slash_count,
+        is_slashed = excluded.is_slashed,
+        periods_json = excluded.periods_json,
+        ledger_seq = excluded.ledger_seq,
+        updated_at = datetime('now')`,
+      [state.contract_id, state.user, state.wrap_count, state.latest_period, state.alias_hash, state.slash_count, state.is_slashed ? 1 : 0, JSON.stringify(state.periods), state.ledger_seq],
+    );
+  }
+
+  // ─── Contract State ─────────────────────────────────────────────────
+
+  upsertContractState(state: {
+    contract_id: string;
+    admin: string | null;
+    admin_pubkey: string | null;
+    pending_admin: string | null;
+    migration_version: number;
+    is_paused: boolean;
+    total_wrap_count: number;
+    total_revoked: number;
+    storage_bytes: number;
+    slash_threshold: number;
+    ledger_seq: number;
+  }): void {
+    this.exec(
+      `INSERT INTO contract_state
+        (contract_id, admin, admin_pubkey, pending_admin, migration_version, is_paused,
+         total_wrap_count, total_revoked, storage_bytes, slash_threshold, ledger_seq)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(contract_id) DO UPDATE SET
+        admin = excluded.admin,
+        admin_pubkey = excluded.admin_pubkey,
+        pending_admin = excluded.pending_admin,
+        migration_version = excluded.migration_version,
+        is_paused = excluded.is_paused,
+        total_wrap_count = excluded.total_wrap_count,
+        total_revoked = excluded.total_revoked,
+        storage_bytes = excluded.storage_bytes,
+        slash_threshold = excluded.slash_threshold,
+        ledger_seq = excluded.ledger_seq,
+        updated_at = datetime('now')`,
+      [state.contract_id, state.admin, state.admin_pubkey, state.pending_admin, state.migration_version, state.is_paused ? 1 : 0, state.total_wrap_count, state.total_revoked, state.storage_bytes, state.slash_threshold, state.ledger_seq],
+    );
+  }
+
+  getContractState(contractId: string): ContractStateRow | null {
+    const row = this.fetchOne(
+      `SELECT * FROM contract_state WHERE contract_id = ?`,
+      [contractId],
+    ) as ContractStateRow | null;
+    return row ?? null;
+  }
+
+  // ─── Storage Snapshots ──────────────────────────────────────────────
+
+  insertStorageSnapshot(entry: StorageEntry, contractId: string): void {
+    this.exec(
+      `INSERT INTO storage_snapshots
+        (contract_id, ledger_seq, key_variant, key_json, value_type, value_json, durability)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [contractId, entry.ledger, String(entry.key.variant), JSON.stringify(entry.key), entry.value.type, JSON.stringify(entry.value), entry.durability],
+    );
+  }
+
+  // ─── Ledger Cursor ──────────────────────────────────────────────────
+
+  getCursor(id: string): LedgerCursorRow | null {
+    const row = this.fetchOne(
+      `SELECT * FROM ledger_cursor WHERE id = ?`,
+      [id],
+    ) as LedgerCursorRow | null;
+    return row ?? null;
+  }
+
+  upsertCursor(id: string, contractId: string, processedLedger: number, eventLedger: number): void {
+    this.exec(
+      `INSERT INTO ledger_cursor (id, contract_id, last_processed_ledger, last_event_ledger)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+        last_processed_ledger = excluded.last_processed_ledger,
+        last_event_ledger = excluded.last_event_ledger,
+        updated_at = datetime('now')`,
+      [id, contractId, processedLedger, eventLedger],
+    );
+  }
+
+  // ─── Stats ──────────────────────────────────────────────────────────
+
+  getStats(contractId: string): Record<string, unknown> {
+    const eventCount = this.fetchOne(
+      `SELECT COUNT(*) as c FROM contract_events WHERE contract_id = ?`,
+      [contractId],
+    ) as { c: number };
+
+    const wrapCount = this.fetchOne(
+      `SELECT COUNT(*) as c FROM wrap_records WHERE contract_id = ?`,
+      [contractId],
+    ) as { c: number };
+
+    const userCount = this.fetchOne(
+      `SELECT COUNT(*) as c FROM user_state WHERE contract_id = ?`,
+      [contractId],
+    ) as { c: number };
+
+    const lastLedger = this.fetchOne(
+      `SELECT MAX(ledger_seq) as ml FROM contract_events WHERE contract_id = ?`,
+      [contractId],
+    ) as { ml: number | null };
+
+    return {
+      contract_id: contractId,
+      total_events: eventCount.c,
+      total_wraps: wrapCount.c,
+      total_users: userCount.c,
+      last_indexed_ledger: lastLedger.ml,
+    };
+  }
+
+  close(): void {
+    this.db.close();
+  }
+}

--- a/pipeline/src/decoder.ts
+++ b/pipeline/src/decoder.ts
@@ -1,0 +1,389 @@
+import {
+  xdr,
+  scValToNative,
+  nativeToScVal,
+  Address,
+} from '@stellar/stellar-sdk';
+import type {
+  DecodedKey,
+  DecodedStorageValue,
+  EventTopic,
+  StorageEntry,
+  WrapRecord,
+  WrapState,
+  FeeParams,
+  WrapLifecycleFSM,
+} from './types';
+import { DataKeyVariant } from './types';
+
+// ─── ScVal helpers ──────────────────────────────────────────────────────
+
+function scvToAddress(val: xdr.ScVal): string {
+  return Address.fromScVal(val).toString();
+}
+
+function scvToBytesN(val: xdr.ScVal, length: number): string {
+  const buf = val.bytes() as Buffer;
+  if (buf.length !== length) {
+    throw new Error(`Expected ${length} bytes, got ${buf.length}`);
+  }
+  return buf.toString('hex');
+}
+
+function scvToSymbol(val: xdr.ScVal): string {
+  return val.sym().toString();
+}
+
+function scvToU64(val: xdr.ScVal): number {
+  const u64 = val.u64();
+  return Number(u64.toString());
+}
+
+function scvToI128(val: xdr.ScVal): bigint {
+  const i128 = val.i128();
+  return BigInt(i128.toString());
+}
+
+function scvToBool(val: xdr.ScVal): boolean {
+  return val.b() === true;
+}
+
+function scvToString(val: xdr.ScVal): string {
+  if (val.str()) {
+    return val.str().toString();
+  }
+  return scValToNative(val);
+}
+
+// ─── DataKey decoder ────────────────────────────────────────────────────
+
+export function decodeDataKey(keyScVal: xdr.ScVal): DecodedKey {
+  const keyVec = keyScVal.vec();
+  if (keyVec === null || keyVec === undefined) {
+    // Instance storage: key is wrapped as VecM of length 1 (the variant symbol)
+    if (keyScVal.sym()) {
+      return decodeSingletonKey(keyScVal.sym().toString());
+    }
+    throw new Error(`Unsupported key format: ${keyScVal.toXDR('base64')}`);
+  }
+
+  if (keyVec.length === 0) {
+    throw new Error('Empty vec key');
+  }
+
+  const variant = keyVec[0];
+  if (!variant.sym()) {
+    throw new Error(`First element of key vec must be a symbol, got: ${variant.toXDR('base64')}`);
+  }
+
+  const variantName = variant.sym().toString();
+  switch (variantName) {
+    // Instance singleton keys (represented as vec for instance storage in snapshots)
+    case 'Admin':
+      return { variant: DataKeyVariant.Admin };
+    case 'AdminPubKey':
+      return { variant: DataKeyVariant.AdminPubKey };
+    case 'PendingAdmin':
+      return { variant: DataKeyVariant.PendingAdmin };
+    case 'MigrationVersion':
+      return { variant: DataKeyVariant.MigrationVersion };
+    case 'TotalWrapCount':
+      return { variant: DataKeyVariant.TotalWrapCount };
+    case 'TotalRevoked':
+      return { variant: DataKeyVariant.TotalRevoked };
+    case 'Name':
+      return { variant: DataKeyVariant.Name };
+    case 'Symbol':
+      return { variant: DataKeyVariant.Symbol };
+    case 'Paused':
+      return { variant: DataKeyVariant.Paused };
+    case 'StorageBytes':
+      return { variant: DataKeyVariant.StorageBytes };
+    case 'FeeParams':
+      return { variant: DataKeyVariant.FeeParams };
+    case 'SlashThreshold':
+      return { variant: DataKeyVariant.SlashThreshold };
+
+    // Keys with Address param
+    case 'WrapCount': {
+      if (keyVec.length < 2) throw new Error('WrapCount needs an address');
+      return { variant: DataKeyVariant.WrapCount, user: scvToAddress(keyVec[1]) };
+    }
+    case 'LatestPeriod': {
+      if (keyVec.length < 2) throw new Error('LatestPeriod needs an address');
+      return { variant: DataKeyVariant.LatestPeriod, user: scvToAddress(keyVec[1]) };
+    }
+    case 'UserPeriods': {
+      if (keyVec.length < 2) throw new Error('UserPeriods needs an address');
+      return { variant: DataKeyVariant.UserPeriods, user: scvToAddress(keyVec[1]) };
+    }
+    case 'AliasHash': {
+      if (keyVec.length < 2) throw new Error('AliasHash needs an address');
+      return { variant: DataKeyVariant.AliasHash, user: scvToAddress(keyVec[1]) };
+    }
+    case 'SlashCount': {
+      if (keyVec.length < 2) throw new Error('SlashCount needs an address');
+      return { variant: DataKeyVariant.SlashCount, user: scvToAddress(keyVec[1]) };
+    }
+    case 'Slashed': {
+      if (keyVec.length < 2) throw new Error('Slashed needs an address');
+      return { variant: DataKeyVariant.Slashed, user: scvToAddress(keyVec[1]) };
+    }
+
+    // Wrap(Address, u64)
+    case 'Wrap': {
+      if (keyVec.length < 3) throw new Error('Wrap needs address and period');
+      return {
+        variant: DataKeyVariant.Wrap,
+        user: scvToAddress(keyVec[1]),
+        period: scvToU64(keyVec[2]),
+      };
+    }
+
+    default:
+      throw new Error(`Unknown DataKey variant: ${variantName}`);
+  }
+}
+
+function decodeSingletonKey(name: string): DecodedKey {
+  switch (name) {
+    case 'Admin': return { variant: DataKeyVariant.Admin };
+    case 'AdminPubKey': return { variant: DataKeyVariant.AdminPubKey };
+    case 'PendingAdmin': return { variant: DataKeyVariant.PendingAdmin };
+    case 'MigrationVersion': return { variant: DataKeyVariant.MigrationVersion };
+    case 'TotalWrapCount': return { variant: DataKeyVariant.TotalWrapCount };
+    case 'TotalRevoked': return { variant: DataKeyVariant.TotalRevoked };
+    case 'Name': return { variant: DataKeyVariant.Name };
+    case 'Symbol': return { variant: DataKeyVariant.Symbol };
+    case 'Paused': return { variant: DataKeyVariant.Paused };
+    case 'StorageBytes': return { variant: DataKeyVariant.StorageBytes };
+    case 'FeeParams': return { variant: DataKeyVariant.FeeParams };
+    case 'SlashThreshold': return { variant: DataKeyVariant.SlashThreshold };
+    default: throw new Error(`Unknown singleton key: ${name}`);
+  }
+}
+
+// ─── Value decoder ──────────────────────────────────────────────────────
+
+function decodeWrapRecord(valMap: xdr.ScMapEntry[]): WrapRecord {
+  const record: Record<string, unknown> = {};
+  for (const entry of valMap) {
+    const key = entry.key().sym().toString();
+    const raw = entry.val();
+
+    switch (key) {
+      case 'timestamp':
+        record.timestamp = scvToU64(raw);
+        break;
+      case 'data_hash':
+        record.data_hash = scvToBytesN(raw, 32);
+        break;
+      case 'archetype':
+        record.archetype = scvToSymbol(raw);
+        break;
+      case 'period':
+        record.period = scvToU64(raw);
+        break;
+      case 'fsm': {
+        const fsmMap = raw.map() ?? [];
+        record.fsm = decodeFSM(fsmMap);
+        break;
+      }
+      case 'updated_at':
+        record.updated_at = scvToU64(raw);
+        break;
+    }
+  }
+
+  return {
+    timestamp: record.timestamp as number,
+    data_hash: record.data_hash as string,
+    archetype: record.archetype as string,
+    period: record.period as number,
+    fsm: record.fsm as WrapLifecycleFSM ?? { state: 3, updated_at: record.timestamp as number },
+  };
+}
+
+function decodeFSM(map: xdr.ScMapEntry[]): WrapLifecycleFSM {
+  let state: WrapState = 3; // default Active
+  let updated_at = 0;
+
+  for (const entry of map) {
+    const key = entry.key().sym().toString();
+    const raw = entry.val();
+    if (key === 'state') {
+      state = scvToU64(raw) as WrapState;
+    } else if (key === 'updated_at') {
+      updated_at = scvToU64(raw);
+    }
+  }
+
+  return { state, updated_at };
+}
+
+function decodeFeeParams(valMap: xdr.ScMapEntry[]): FeeParams {
+  let baseFee = 0n;
+  let perKibFee = 0n;
+  let scaleStepKib = 1;
+  let maxFee = BigInt(Number.MAX_SAFE_INTEGER);
+
+  for (const entry of valMap) {
+    const key = entry.key().sym().toString();
+    const raw = entry.val();
+    switch (key) {
+      case 'base_fee':
+        baseFee = scvToI128(raw);
+        break;
+      case 'per_kib_fee':
+        perKibFee = scvToI128(raw);
+        break;
+      case 'scale_step_kib':
+        scaleStepKib = scvToU64(raw);
+        break;
+      case 'max_fee':
+        maxFee = scvToI128(raw);
+        break;
+    }
+  }
+
+  return {
+    base_fee: baseFee,
+    per_kib_fee: perKibFee,
+    scale_step_kib: scaleStepKib,
+    max_fee: maxFee,
+  };
+}
+
+function decodeVecU64(val: xdr.ScVal): number[] {
+  const v = val.vec();
+  if (!v) return [];
+  const result: number[] = [];
+  for (const element of v) {
+    result.push(scvToU64(element));
+  }
+  return result;
+}
+
+export function decodeStorageValue(
+  key: DecodedKey,
+  valueScVal: xdr.ScVal,
+): DecodedStorageValue {
+  switch (key.variant) {
+    case DataKeyVariant.Admin:
+    case DataKeyVariant.PendingAdmin:
+      return { type: 'address', value: Address.fromScVal(valueScVal).toString() };
+
+    case DataKeyVariant.AdminPubKey:
+    case DataKeyVariant.AliasHash:
+      return { type: 'bytes32', value: scvToBytesN(valueScVal, 32) };
+
+    case DataKeyVariant.MigrationVersion:
+    case DataKeyVariant.TotalWrapCount:
+    case DataKeyVariant.WrapCount:
+    case DataKeyVariant.SlashCount:
+    case DataKeyVariant.SlashThreshold:
+      return { type: 'u32', value: Number(scValToNative(valueScVal)) };
+
+    case DataKeyVariant.LatestPeriod:
+    case DataKeyVariant.TotalRevoked:
+    case DataKeyVariant.StorageBytes:
+      return { type: 'u64', value: scvToU64(valueScVal) };
+
+    case DataKeyVariant.Paused:
+    case DataKeyVariant.Slashed:
+      return { type: 'bool', value: scvToBool(valueScVal) };
+
+    case DataKeyVariant.Name:
+    case DataKeyVariant.Symbol:
+      return { type: 'string', value: scvToString(valueScVal) };
+
+    case DataKeyVariant.Wrap: {
+      const valMap = valueScVal.map() ?? [];
+      return { type: 'wrap_record', value: decodeWrapRecord(valMap) };
+    }
+
+    case DataKeyVariant.FeeParams: {
+      const valMap = valueScVal.map() ?? [];
+      return { type: 'fee_params', value: decodeFeeParams(valMap) };
+    }
+
+    case DataKeyVariant.UserPeriods:
+      return { type: 'u64_vec', value: decodeVecU64(valueScVal) };
+
+    default:
+      throw new Error(`decodeStorageValue not implemented for ${(key as DecodedKey).variant}`);
+  }
+}
+
+// ─── Event decoder ──────────────────────────────────────────────────────
+
+export function decodeEventTopic(val: xdr.ScVal): EventTopic {
+  switch (val.switch().name) {
+    case 'scvSymbol':
+      return { type: 'symbol', value: val.sym().toString() };
+    case 'scvAddress':
+      return { type: 'address', value: Address.fromScVal(val).toString() };
+    case 'scvU64':
+      return { type: 'u64', value: scvToU64(val) };
+    case 'scvU32':
+      return { type: 'u32', value: val.u32() };
+    case 'scvBool':
+      return { type: 'bool', value: val.b() };
+    case 'scvBytes':
+      return { type: 'bytes', value: Buffer.from(val.bytes()).toString('hex') };
+    default:
+      return { type: 'symbol', value: scValToNative(val)?.toString() ?? 'unknown' };
+  }
+}
+
+export function decodeEventData(val: xdr.ScVal): DecodedStorageValue {
+  const switchName = val.switch().name;
+  switch (switchName) {
+    case 'scvSymbol':
+      return { type: 'string', value: val.sym().toString() };
+    case 'scvAddress':
+      return { type: 'address', value: Address.fromScVal(val).toString() };
+    case 'scvU64':
+      return { type: 'u64', value: scvToU64(val) };
+    case 'scvU32':
+      return { type: 'u32', value: val.u32() };
+    case 'scvBool':
+      return { type: 'bool', value: val.b() };
+    case 'scvBytes':
+      return { type: 'bytes', value: Buffer.from(val.bytes()).toString('hex') };
+    case 'scvMap':
+      return { type: 'string', value: JSON.stringify(scValToNative(val)) };
+    case 'scvVec':
+      return { type: 'string', value: JSON.stringify(scValToNative(val)) };
+    default:
+      return { type: 'string', value: JSON.stringify(scValToNative(val)) };
+  }
+}
+
+// ─── Storage entry decoder ──────────────────────────────────────────────
+
+export function decodeLedgerEntry(
+  ledgerKey: xdr.LedgerKey,
+  ledgerEntry: xdr.LedgerEntry,
+): StorageEntry | null {
+  const ledgerData = ledgerEntry.data();
+
+  if (ledgerData.switch().name !== 'contractData') {
+    return null;
+  }
+
+  const contractData = ledgerData.contractData();
+  const keyScVal = contractData.key();
+  const valScVal = contractData.val();
+  const durability = contractData.durability().name.toLowerCase() as 'persistent' | 'temporary' | 'instance';
+
+  const decodedKey = decodeDataKey(keyScVal);
+  const decodedValue = decodeStorageValue(decodedKey, valScVal);
+
+  return {
+    key: decodedKey,
+    value: decodedValue,
+    ledger: ledgerEntry.lastModifiedLedgerSeq(),
+    durability,
+  };
+}

--- a/pipeline/src/fetcher.ts
+++ b/pipeline/src/fetcher.ts
@@ -1,0 +1,195 @@
+import { rpc, xdr, Address } from '@stellar/stellar-sdk';
+import type { ContractEvent, StorageEntry } from './types';
+import { decodeEventTopic, decodeEventData, decodeLedgerEntry } from './decoder';
+
+export interface FetcherOptions {
+  rpcUrl: string;
+  contractId: string;
+  eventPageSize: number;
+}
+
+export class SorobanFetcher {
+  private server: rpc.Server;
+  private contractId: string;
+  private eventPageSize: number;
+
+  constructor(opts: FetcherOptions) {
+    this.server = new rpc.Server(opts.rpcUrl);
+    this.contractId = opts.contractId;
+    this.eventPageSize = opts.eventPageSize;
+  }
+
+  /**
+   * Fetch contract events from Soroban-RPC.
+   * Returns events and the latest ledger sequence seen.
+   */
+  async fetchEvents(
+    startLedger: number,
+    topicsFilter?: string[],
+  ): Promise<{ events: ContractEvent[]; latestLedger: number }> {
+    const filters: rpc.Api.EventFilter[] = [
+      {
+        type: 'contract',
+        contractIds: [this.contractId],
+        topics: topicsFilter
+          ? topicsFilter.map((t) => [
+              xdr.ScVal.scvSymbol(t).toXDR('base64'),
+            ])
+          : undefined,
+      },
+    ];
+
+    const response = await this.server.getEvents({
+      startLedger,
+      filters,
+      limit: this.eventPageSize,
+    });
+
+    const events: ContractEvent[] = (response.events || []).map((evt) =>
+      this.parseRawEvent(evt),
+    );
+
+    return {
+      events,
+      latestLedger: response.latestLedger,
+    };
+  }
+
+  private parseRawEvent(raw: rpc.Api.EventResponse): ContractEvent {
+    const topics: ContractEvent['topics'] = raw.topic.map((t) =>
+      t instanceof xdr.ScVal ? decodeEventTopic(t) : { type: 'symbol' as const, value: String(t) },
+    );
+
+    const data: ContractEvent['data'] = decodeEventData(raw.value as xdr.ScVal);
+
+    return {
+      id: raw.id,
+      contract_id: String(raw.contractId),
+      ledger: raw.ledger,
+      ledger_close_at: null,
+      tx_hash: raw.txHash,
+      topics,
+      data,
+      failed_call: false,
+    };
+  }
+
+  /**
+   * Fetch current storage entries for the contract from Soroban-RPC.
+   * This returns the latest state, not historical snapshots.
+   */
+  async fetchStorageEntries(): Promise<StorageEntry[]> {
+    const response = await this.server.getLedgerEntries();
+    const entries: StorageEntry[] = [];
+
+    for (const rawEntry of response.entries || []) {
+      try {
+        // We need to iterate over all possible ledger keys.
+        // The response returns all entries - we filter to our contract.
+        const ledgerEntry = rawEntry as unknown as {
+          key: xdr.LedgerKey;
+          entry: xdr.LedgerEntry;
+        };
+
+        const decoded = decodeLedgerEntry(ledgerEntry.key, ledgerEntry.entry);
+        if (decoded) {
+          entries.push(decoded);
+        }
+      } catch (e) {
+        // Skip entries we can't decode
+        continue;
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Fetch specific storage entries by key.
+   * Uses `getLedgerEntries` with specific ledger keys for targeted fetching.
+   */
+  async fetchStorageByKeys(ledgerKeys: xdr.LedgerKey[]): Promise<StorageEntry[]> {
+    if (ledgerKeys.length === 0) return [];
+
+    const response = await this.server.getLedgerEntries(...ledgerKeys);
+    const entries: StorageEntry[] = [];
+
+    for (const rawEntry of response.entries || []) {
+      try {
+        const ledgerEntry = rawEntry as unknown as {
+          key: xdr.LedgerKey;
+          entry: xdr.LedgerEntry;
+        };
+        const decoded = decodeLedgerEntry(ledgerEntry.key, ledgerEntry.entry);
+        if (decoded) {
+          entries.push(decoded);
+        }
+      } catch (e) {
+        continue;
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Build a LedgerKey for DataKey::Wrap(user, period) for targeted fetching.
+   */
+  buildWrapKey(user: string, period: number): xdr.LedgerKey {
+    const contractId = Address.fromString(this.contractId).toScAddress();
+    const userAddr = Address.fromString(user).toScVal();
+    const periodVal = xdr.ScVal.scvU64(new xdr.Uint64(period));
+
+    const key = xdr.ScVal.scvVec([
+      xdr.ScVal.scvSymbol('Wrap'),
+      userAddr,
+      periodVal,
+    ]);
+
+    return xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        durability: xdr.ContractDataDurability.persistent(),
+        contract: contractId,
+        key,
+      }),
+    );
+  }
+
+  /**
+   * Fetch the latest ledger sequence from the network.
+   */
+  async getLatestLedger(): Promise<number> {
+    const info = await this.server.getLatestLedger();
+    return info.sequence;
+  }
+
+  /**
+   * Build a LedgerKey for a general DataKey.
+   */
+  buildDataKey(variant: string, args: (string | number)[] = []): xdr.LedgerKey {
+    const contractId = Address.fromString(this.contractId).toScAddress();
+
+    const vec: xdr.ScVal[] = [xdr.ScVal.scvSymbol(variant)];
+    for (const arg of args) {
+      if (typeof arg === 'string') {
+        vec.push(Address.fromString(arg).toScVal());
+      } else {
+        vec.push(xdr.ScVal.scvU64(new xdr.Uint64(arg)));
+      }
+    }
+
+    const key = xdr.ScVal.scvVec(vec);
+
+    const isInstance = ['Admin', 'AdminPubKey', 'PendingAdmin', 'MigrationVersion',
+      'Paused', 'Name', 'Symbol', 'StorageBytes', 'FeeParams', 'SlashThreshold',
+      'TotalRevoked'].includes(variant);
+
+    return xdr.LedgerKey.contractData(
+      new xdr.LedgerKeyContractData({
+        durability: isInstance ? xdr.ContractDataDurability.persistent() : xdr.ContractDataDurability.persistent(),
+        contract: contractId,
+        key,
+      }),
+    );
+  }
+}

--- a/pipeline/src/index.ts
+++ b/pipeline/src/index.ts
@@ -1,0 +1,143 @@
+import { loadConfig } from './config';
+import { IndexerDB } from './db';
+import { SorobanFetcher } from './fetcher';
+import { processEventBatch, createEmptyState, persistStateToDB } from './processor';
+import { backfillEvents } from './backfill';
+import { reconcile } from './reconciler';
+import type { DerivedState } from './types';
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  const db = await IndexerDB.create(config.db_path);
+  const fetcher = new SorobanFetcher({
+    rpcUrl: config.rpc_url,
+    contractId: config.contract_id,
+    eventPageSize: config.event_page_size,
+  });
+
+  console.log('Soroban-RPC Indexer Pipeline');
+  console.log('============================');
+  console.log(`Contract: ${config.contract_id}`);
+  console.log(`RPC URL:  ${config.rpc_url}`);
+  console.log(`DB Path:  ${config.db_path}`);
+
+  // ── Reconcile-only mode ────────────────────────────────────────────
+  if (config.reconcile_only) {
+    console.log('\nRunning reconciliation...');
+    const report = await reconcile(db, fetcher, config.contract_id);
+    console.log(`\nReconciliation ${report.is_consistent ? 'PASSED' : 'FAILED'}`);
+    if (report.mismatches.length > 0) {
+      console.log('Mismatches:');
+      for (const m of report.mismatches) {
+        console.log(`  - ${m}`);
+      }
+    }
+    console.log(`Indexed wraps: ${report.indexed.total_wraps}`);
+    console.log(`On-chain wraps: ${report.onchain.total_wraps}`);
+    db.close();
+    return;
+  }
+
+  // ── Backfill mode ──────────────────────────────────────────────────
+  if (config.backfill) {
+    console.log('\nStarting historical backfill...');
+    await backfillEvents({
+      fetcher,
+      db,
+      contractId: config.contract_id,
+      startLedger: config.start_ledger,
+      onProgress: (processed, ledger) => {
+        if (processed % 500 === 0) {
+          console.log(`  Processed ${processed} events (ledger ${ledger})`);
+        }
+      },
+    });
+    console.log('Backfill complete.');
+
+    // Run reconciliation after backfill
+    console.log('\nRunning post-backfill reconciliation...');
+    const report = await reconcile(db, fetcher, config.contract_id);
+    console.log(`Reconciliation: ${report.is_consistent ? 'PASSED' : 'FAILED'}`);
+    for (const m of report.mismatches) {
+      console.log(`  - ${m}`);
+    }
+
+    db.close();
+    return;
+  }
+
+  // ── Live indexing mode ─────────────────────────────────────────────
+  console.log('\nStarting live indexing...');
+
+  // Determine starting ledger from cursor or start_ledger config
+  const cursor = db.getCursor(`cursor:${config.contract_id}`);
+  let startLedger = cursor ? cursor.last_processed_ledger + 1 : config.start_ledger;
+
+  // Initialize state from DB or create empty
+  let state: DerivedState;
+  const existingState = db.getContractState(config.contract_id);
+  if (existingState) {
+    state = createEmptyState(config.contract_id, startLedger);
+    // Load wraps from DB
+    console.log('Loading existing indexed state...');
+  } else {
+    state = createEmptyState(config.contract_id, startLedger);
+  }
+
+  console.log(`Starting from ledger ${startLedger}`);
+  console.log(`Polling every ${config.poll_interval_ms}ms\n`);
+
+  // Main polling loop
+  let consecutiveErrors = 0;
+
+  while (true) {
+    try {
+      const { events, latestLedger } = await fetcher.fetchEvents(startLedger);
+
+      if (events.length > 0) {
+        const processed = processEventBatch(db, state, events);
+        const firstLedger = events[0].ledger;
+        const lastLedger = events[events.length - 1].ledger;
+        console.log(
+          `[${new Date().toISOString()}] Indexed ${processed} events ` +
+          `(ledgers ${firstLedger}-${lastLedger}, latest: ${latestLedger})`,
+        );
+      }
+
+      if (latestLedger > 0) {
+        startLedger = latestLedger + 1;
+        db.upsertCursor(
+          `cursor:${config.contract_id}`,
+          config.contract_id,
+          latestLedger,
+          latestLedger,
+        );
+      }
+
+      consecutiveErrors = 0;
+
+    } catch (err) {
+      consecutiveErrors++;
+      console.error(`Error (${consecutiveErrors}):`, err instanceof Error ? err.message : err);
+
+      if (consecutiveErrors >= 10) {
+        console.error('Too many consecutive errors. Exiting.');
+        break;
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, config.poll_interval_ms));
+  }
+
+  db.close();
+}
+
+process.on('unhandledRejection', (err) => {
+  console.error('Unhandled rejection:', err);
+  process.exit(1);
+});
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/pipeline/src/processor.ts
+++ b/pipeline/src/processor.ts
@@ -1,0 +1,503 @@
+import type {
+  ContractEvent,
+  EventTopic,
+  TypedEvent,
+  EventType,
+  WrapRecord,
+  StorageEntry,
+  DerivedState,
+} from './types';
+import { DataKeyVariant } from './types';
+import { SorobanFetcher } from './fetcher';
+import { IndexerDB } from './db';
+import { decodeDataKey, decodeStorageValue } from './decoder';
+
+// ─── Event classification ──────────────────────────────────────────────
+
+export function classifyEvent(event: ContractEvent): TypedEvent {
+  if (event.topics.length < 1) {
+    return { raw: event, event_type: 'unknown', parsed: {} };
+  }
+
+  const t0 = event.topics[0];
+  if (t0.type !== 'symbol') {
+    return { raw: event, event_type: 'unknown', parsed: {} };
+  }
+
+  switch (t0.value) {
+    case 'mint':
+      return classifyMintEvent(event);
+    case 'revoke':
+      return classifyRevokeEvent(event);
+    case 'trans':
+      return classifyTransitionEvent(event);
+    case 'init':
+      return {
+        raw: event,
+        event_type: 'init',
+        parsed: { admin: event.topics[1]?.value },
+      };
+    case 'pause':
+      return {
+        raw: event,
+        event_type: 'pause',
+        parsed: { paused: event.data.value },
+      };
+    case 'upgrade':
+      return {
+        raw: event,
+        event_type: 'upgrade',
+        parsed: { new_wasm_hash: event.data.value },
+      };
+    case 'admin': {
+      const subType = event.topics[1];
+      return {
+        raw: event,
+        event_type: 'admin_update',
+        parsed: {
+          action: subType.type === 'symbol' ? subType.value : 'updated',
+          data: event.data.value,
+        },
+      };
+    }
+    case 'slash': {
+      const subType = event.topics[1];
+      if (subType.type === 'symbol') {
+        switch (subType.value) {
+          case 'report':
+            return classifySlashReportEvent(event);
+          case 'clear':
+            return classifySlashClearEvent(event);
+          case 'thresh':
+            return classifySlashThresholdEvent(event);
+        }
+      }
+      return { raw: event, event_type: 'unknown', parsed: {} };
+    }
+    default:
+      return { raw: event, event_type: 'unknown', parsed: {} };
+  }
+}
+
+function classifyMintEvent(event: ContractEvent): TypedEvent {
+  const user = event.topics[1]?.value;
+  const period = event.topics[2]?.value;
+  const archetype = event.data.value;
+
+  return {
+    raw: event,
+    event_type: 'mint',
+    parsed: {
+      user,
+      period: typeof period === 'number' ? period : Number(period),
+      archetype,
+    },
+  };
+}
+
+function classifyRevokeEvent(event: ContractEvent): TypedEvent {
+  const user = event.topics[1]?.value;
+  const period = event.topics[2]?.value;
+  const reasonHash = event.data.value;
+
+  return {
+    raw: event,
+    event_type: 'revoke',
+    parsed: {
+      user,
+      period: typeof period === 'number' ? period : Number(period),
+      reason_hash: reasonHash,
+    },
+  };
+}
+
+function classifyTransitionEvent(event: ContractEvent): TypedEvent {
+  const user = event.topics[1]?.value;
+  const period = event.topics[2]?.value;
+  const nextState = event.data.value;
+
+  return {
+    raw: event,
+    event_type: 'transition',
+    parsed: {
+      user,
+      period: typeof period === 'number' ? period : Number(period),
+      next_state: typeof nextState === 'number' ? nextState : Number(nextState),
+    },
+  };
+}
+
+function classifySlashReportEvent(event: ContractEvent): TypedEvent {
+  const dataVal = event.data.value;
+  let user = '';
+  let count = 0;
+  if (typeof dataVal === 'object' && dataVal !== null) {
+    const arr = Array.isArray(dataVal) ? dataVal : Object.values(dataVal as any);
+    if (arr.length >= 2) {
+      user = String(arr[0]);
+      count = Number(arr[1]);
+    }
+  }
+
+  return {
+    raw: event,
+    event_type: 'slash_report',
+    parsed: { user, count },
+  };
+}
+
+function classifySlashClearEvent(event: ContractEvent): TypedEvent {
+  return {
+    raw: event,
+    event_type: 'slash_clear',
+    parsed: { user: event.data.value },
+  };
+}
+
+function classifySlashThresholdEvent(event: ContractEvent): TypedEvent {
+  return {
+    raw: event,
+    event_type: 'slash_threshold',
+    parsed: { threshold: event.data.value },
+  };
+}
+
+// ─── State derivation from events ──────────────────────────────────────
+
+export function createEmptyState(contractId: string, ledgerSeq: number): DerivedState {
+  return {
+    contract_id: contractId,
+    ledger_seq: ledgerSeq,
+    wraps: new Map(),
+    userCounts: new Map(),
+    userLatestPeriods: new Map(),
+    userPeriods: new Map(),
+    userAliasHashes: new Map(),
+    userSlashCounts: new Map(),
+    userSlashed: new Map(),
+    admin: null,
+    adminPubKey: null,
+    pendingAdmin: null,
+    migrationVersion: 0,
+    paused: false,
+    totalWrapCount: 0,
+    totalRevoked: 0,
+    storageBytes: 0,
+    slashThreshold: 3,
+    name: null,
+    symbol: null,
+  };
+}
+
+export function applyEventToState(state: DerivedState, event: TypedEvent): void {
+  switch (event.event_type) {
+    case 'mint':
+      applyMintEvent(state, event);
+      break;
+    case 'revoke':
+      applyRevokeEvent(state, event);
+      break;
+    case 'transition':
+      applyTransitionEvent(state, event);
+      break;
+    case 'init':
+      state.admin = String(event.parsed.admin ?? '');
+      break;
+    case 'pause':
+      state.paused = Boolean(event.parsed.paused);
+      break;
+    case 'admin_update':
+      if (event.parsed.action === 'updated' && Array.isArray(event.parsed.data)) {
+        const data = event.parsed.data as [unknown, unknown];
+        state.admin = String(data[1] ?? '');
+      }
+      break;
+    case 'slash_report': {
+      const user = String(event.parsed.user ?? '');
+      const count = Number(event.parsed.count ?? 0);
+      state.userSlashCounts.set(user, count);
+      break;
+    }
+    case 'slash_clear': {
+      const user = String(event.parsed.user ?? '');
+      state.userSlashCounts.delete(user);
+      state.userSlashed.delete(user);
+      break;
+    }
+    case 'slash_threshold':
+      state.slashThreshold = Number(event.parsed.threshold ?? 3);
+      break;
+    default:
+      break;
+  }
+}
+
+function applyMintEvent(state: DerivedState, event: TypedEvent): void {
+  const user = String(event.parsed.user ?? '');
+  const period = Number(event.parsed.period ?? 0);
+  const archetype = String(event.parsed.archetype ?? '');
+
+  // Create a placeholder wrap record from the mint event
+  const record: WrapRecord = {
+    timestamp: 0, // Not available from event; filled from storage
+    data_hash: '', // Not available from event; filled from storage
+    archetype,
+    period,
+    fsm: { state: 3, updated_at: 0 }, // Active by default
+  };
+
+  let userWraps = state.wraps.get(user);
+  if (!userWraps) {
+    userWraps = new Map();
+    state.wraps.set(user, userWraps);
+  }
+  userWraps.set(period, record);
+
+  // Increment wrap count
+  const currentCount = state.userCounts.get(user) ?? 0;
+  state.userCounts.set(user, currentCount + 1);
+  state.totalWrapCount += 1;
+
+  // Update latest period
+  const currentLatest = state.userLatestPeriods.get(user) ?? 0;
+  if (period > currentLatest) {
+    state.userLatestPeriods.set(user, period);
+  }
+
+  // Add to periods list
+  const periods = state.userPeriods.get(user) ?? [];
+  if (!periods.includes(period)) {
+    periods.push(period);
+    periods.sort((a, b) => a - b);
+    state.userPeriods.set(user, periods);
+  }
+}
+
+function applyRevokeEvent(state: DerivedState, event: TypedEvent): void {
+  const user = String(event.parsed.user ?? '');
+  const period = Number(event.parsed.period ?? 0);
+
+  const userWraps = state.wraps.get(user);
+  if (userWraps) {
+    userWraps.delete(period);
+    if (userWraps.size === 0) {
+      state.wraps.delete(user);
+    }
+  }
+
+  const currentCount = state.userCounts.get(user) ?? 0;
+  if (currentCount > 0) {
+    state.userCounts.set(user, currentCount - 1);
+  }
+  state.totalRevoked += 1;
+
+  // Remove from periods list
+  const periods = state.userPeriods.get(user) ?? [];
+  const idx = periods.indexOf(period);
+  if (idx !== -1) {
+    periods.splice(idx, 1);
+    state.userPeriods.set(user, periods);
+  }
+}
+
+function applyTransitionEvent(state: DerivedState, event: TypedEvent): void {
+  const user = String(event.parsed.user ?? '');
+  const period = Number(event.parsed.period ?? 0);
+  const nextState = Number(event.parsed.next_state ?? 0);
+
+  const userWraps = state.wraps.get(user);
+  if (userWraps) {
+    const record = userWraps.get(period);
+    if (record) {
+      record.fsm.state = nextState as WrapRecord['fsm']['state'];
+      record.fsm.updated_at = event.raw.ledger;
+    }
+  }
+}
+
+// ─── Apply storage entries to state ────────────────────────────────────
+
+export function applyStorageEntryToState(state: DerivedState, entry: StorageEntry): void {
+  switch (entry.key.variant) {
+    case DataKeyVariant.Admin:
+      state.admin = entry.value.type === 'address' ? entry.value.value : null;
+      break;
+    case DataKeyVariant.AdminPubKey:
+      state.adminPubKey = entry.value.type === 'bytes32' ? entry.value.value : null;
+      break;
+    case DataKeyVariant.PendingAdmin:
+      state.pendingAdmin = entry.value.type === 'address' ? entry.value.value : null;
+      break;
+    case DataKeyVariant.MigrationVersion:
+      state.migrationVersion = entry.value.type === 'u32' ? entry.value.value : 0;
+      break;
+    case DataKeyVariant.Paused:
+      state.paused = entry.value.type === 'bool' ? entry.value.value : false;
+      break;
+    case DataKeyVariant.Name:
+      state.name = entry.value.type === 'string' ? entry.value.value : null;
+      break;
+    case DataKeyVariant.Symbol:
+      state.symbol = entry.value.type === 'string' ? entry.value.value : null;
+      break;
+    case DataKeyVariant.StorageBytes:
+      state.storageBytes = entry.value.type === 'u64' ? entry.value.value : 0;
+      break;
+    case DataKeyVariant.TotalWrapCount:
+      state.totalWrapCount = entry.value.type === 'u32' ? entry.value.value : 0;
+      break;
+    case DataKeyVariant.TotalRevoked:
+      state.totalRevoked = entry.value.type === 'u64' ? entry.value.value : 0;
+      break;
+    case DataKeyVariant.SlashThreshold:
+      state.slashThreshold = entry.value.type === 'u32' ? entry.value.value : 3;
+      break;
+    case DataKeyVariant.Wrap: {
+      if (entry.value.type === 'wrap_record') {
+        const user = (entry.key as { user: string }).user;
+        const period = (entry.key as { period: number }).period;
+        let userWraps = state.wraps.get(user);
+        if (!userWraps) {
+          userWraps = new Map();
+          state.wraps.set(user, userWraps);
+        }
+        userWraps.set(period, entry.value.value);
+      }
+      break;
+    }
+    case DataKeyVariant.WrapCount: {
+      const user = (entry.key as { user: string }).user;
+      state.userCounts.set(user, entry.value.type === 'u32' ? entry.value.value : 0);
+      break;
+    }
+    case DataKeyVariant.LatestPeriod: {
+      const user = (entry.key as { user: string }).user;
+      state.userLatestPeriods.set(user, entry.value.type === 'u64' ? entry.value.value : 0);
+      break;
+    }
+    case DataKeyVariant.UserPeriods: {
+      const user = (entry.key as { user: string }).user;
+      state.userPeriods.set(user, entry.value.type === 'u64_vec' ? entry.value.value : []);
+      break;
+    }
+    case DataKeyVariant.AliasHash: {
+      const user = (entry.key as { user: string }).user;
+      state.userAliasHashes.set(user, entry.value.type === 'bytes32' ? entry.value.value : '');
+      break;
+    }
+    case DataKeyVariant.SlashCount: {
+      const user = (entry.key as { user: string }).user;
+      state.userSlashCounts.set(user, entry.value.type === 'u32' ? entry.value.value : 0);
+      break;
+    }
+    case DataKeyVariant.Slashed: {
+      const user = (entry.key as { user: string }).user;
+      state.userSlashed.set(user, entry.value.type === 'bool' ? entry.value.value : false);
+      break;
+    }
+  }
+}
+
+// ─── Persist derived state to DB ───────────────────────────────────────
+
+export function persistStateToDB(db: IndexerDB, state: DerivedState): void {
+  // Persist contract state
+  db.upsertContractState({
+    contract_id: state.contract_id,
+    admin: state.admin,
+    admin_pubkey: state.adminPubKey,
+    pending_admin: state.pendingAdmin,
+    migration_version: state.migrationVersion,
+    is_paused: state.paused,
+    total_wrap_count: state.totalWrapCount,
+    total_revoked: state.totalRevoked,
+    storage_bytes: state.storageBytes,
+    slash_threshold: state.slashThreshold,
+    ledger_seq: state.ledger_seq,
+  });
+
+  // Persist wraps
+  for (const [user, periodMap] of state.wraps.entries()) {
+    for (const [period, record] of periodMap.entries()) {
+      db.upsertWrap({
+        contract_id: state.contract_id,
+        user,
+        period,
+        timestamp: record.timestamp,
+        data_hash: record.data_hash,
+        archetype: record.archetype,
+        fsm_state: record.fsm.state,
+        fsm_updated_at: record.fsm.updated_at,
+        ledger_seq: state.ledger_seq,
+        tx_hash: '',
+      });
+    }
+  }
+
+  // Persist user state
+  const allUsers = new Set([
+    ...state.wraps.keys(),
+    ...state.userCounts.keys(),
+    ...state.userLatestPeriods.keys(),
+    ...state.userPeriods.keys(),
+    ...state.userAliasHashes.keys(),
+    ...state.userSlashCounts.keys(),
+    ...state.userSlashed.keys(),
+  ]);
+
+  for (const user of allUsers) {
+    db.upsertUserState({
+      contract_id: state.contract_id,
+      user,
+      wrap_count: state.userCounts.get(user) ?? 0,
+      latest_period: state.userLatestPeriods.get(user) ?? null,
+      alias_hash: state.userAliasHashes.get(user) ?? null,
+      slash_count: state.userSlashCounts.get(user) ?? 0,
+      is_slashed: state.userSlashed.get(user) ?? false,
+      periods: state.userPeriods.get(user) ?? [],
+      ledger_seq: state.ledger_seq,
+    });
+  }
+}
+
+// ─── Orchestration helper ──────────────────────────────────────────────
+
+/**
+ * Process a batch of raw contract events: classify, apply to state, and persist.
+ */
+export function processEventBatch(
+  db: IndexerDB,
+  state: DerivedState,
+  events: ContractEvent[],
+): number {
+  let processed = 0;
+
+  for (const event of events) {
+    if (event.failed_call) continue;
+
+    const typed = classifyEvent(event);
+    applyEventToState(state, typed);
+
+    // Persist the raw event
+    db.insertEvent({
+      id: event.id,
+      contract_id: event.contract_id,
+      event_type: typed.event_type,
+      ledger_seq: event.ledger,
+      tx_hash: event.tx_hash,
+      topics_json: JSON.stringify(event.topics),
+      data_json: JSON.stringify(event.data),
+      failed_call: event.failed_call,
+    });
+
+    processed++;
+  }
+
+  // Persist derived state after batch
+  state.ledger_seq = events.length > 0
+    ? events[events.length - 1].ledger
+    : state.ledger_seq;
+  persistStateToDB(db, state);
+
+  return processed;
+}

--- a/pipeline/src/reconciler.ts
+++ b/pipeline/src/reconciler.ts
@@ -1,0 +1,85 @@
+import { Address, xdr } from '@stellar/stellar-sdk';
+import { SorobanFetcher } from './fetcher';
+import { IndexerDB } from './db';
+import { decodeDataKey, decodeStorageValue } from './decoder';
+import { applyStorageEntryToState, createEmptyState } from './processor';
+import type { DerivedState, StorageEntry } from './types';
+import { DataKeyVariant } from './types';
+
+export interface ReconciliationReport {
+  contract_id: string;
+  ledger_seq: number;
+  indexed: {
+    total_wraps: number;
+    total_users: number;
+    contract_state_version: number;
+  };
+  onchain: {
+    total_wraps: number;
+    contract_state: number;
+  };
+  mismatches: string[];
+  is_consistent: boolean;
+}
+
+/**
+ * Reconcile indexed state against current on-chain storage.
+ * Fetches all current storage entries and compares with the database.
+ */
+export async function reconcile(
+  db: IndexerDB,
+  fetcher: SorobanFetcher,
+  contractId: string,
+): Promise<ReconciliationReport> {
+  const mismatches: string[] = [];
+  const onChainState = createEmptyState(contractId, 0);
+
+  // Fetch all current storage entries
+  const storageEntries = await fetcher.fetchStorageEntries();
+
+  // Build on-chain state from entries
+  for (const entry of storageEntries) {
+    applyStorageEntryToState(onChainState, entry);
+  }
+
+  // Get indexed state from DB
+  const indexedState = db.getContractState(contractId);
+  const indexedWrapCount = db.getWrapCount(contractId);
+
+  // Compare contract state
+  if (indexedState) {
+    compareFields('admin', indexedState.admin, onChainState.admin, mismatches);
+    compareFields('admin_pubkey', indexedState.admin_pubkey, onChainState.adminPubKey, mismatches);
+    compareFields('total_wrap_count', indexedState.total_wrap_count, onChainState.totalWrapCount, mismatches);
+    compareFields('total_revoked', indexedState.total_revoked, onChainState.totalRevoked, mismatches);
+    compareFields('storage_bytes', indexedState.storage_bytes, onChainState.storageBytes, mismatches);
+    compareFields('slash_threshold', indexedState.slash_threshold, onChainState.slashThreshold, mismatches);
+    compareFields('is_paused', indexedState.is_paused ? true : false, onChainState.paused, mismatches);
+  }
+
+  const isConsistent = mismatches.length === 0;
+
+  return {
+    contract_id: contractId,
+    ledger_seq: onChainState.ledger_seq,
+    indexed: {
+      total_wraps: indexedWrapCount,
+      total_users: 0,
+      contract_state_version: indexedState?.migration_version ?? 0,
+    },
+    onchain: {
+      total_wraps: onChainState.totalWrapCount,
+      contract_state: onChainState.migrationVersion,
+    },
+    mismatches,
+    is_consistent: isConsistent,
+  };
+}
+
+function compareFields(field: string, a: unknown, b: unknown, mismatches: string[]): void {
+  const aStr = a != null ? String(a) : '<null>';
+  const bStr = b != null ? String(b) : '<null>';
+  if (aStr !== bStr) {
+    mismatches.push(`${field}: indexed="${aStr}" on-chain="${bStr}"`);
+  }
+}

--- a/pipeline/src/sql.js.d.ts
+++ b/pipeline/src/sql.js.d.ts
@@ -1,0 +1,29 @@
+declare module 'sql.js' {
+  interface SqlJsStatic {
+    Database: new (data?: ArrayLike<number> | Buffer | null) => Database;
+  }
+
+  interface QueryExecResult {
+    columns: string[];
+    values: any[][];
+  }
+
+  interface Statement {
+    bind(params?: any[]): boolean;
+    step(): boolean;
+    getAsObject(params?: object): Record<string, unknown>;
+    free(): boolean;
+    reset(): void;
+  }
+
+  interface Database {
+    run(sql: string, params?: any[]): Database;
+    exec(sql: string): QueryExecResult[];
+    prepare(sql: string): Statement;
+    export(): Uint8Array;
+    close(): void;
+  }
+
+  export type { SqlJsStatic, Database, Statement, QueryExecResult };
+  export default function initSqlJs(config?: any): Promise<SqlJsStatic>;
+}

--- a/pipeline/src/types.ts
+++ b/pipeline/src/types.ts
@@ -1,0 +1,270 @@
+import { Address } from '@stellar/stellar-sdk';
+
+// ─── On-chain enum mirrors ─────────────────────────────────────────────
+
+export enum WrapState {
+  Draft = 1,
+  Pending = 2,
+  Active = 3,
+  Archived = 4,
+  Cancelled = 5,
+}
+
+export enum ContractErrorCode {
+  AlreadyInitialized = 1,
+  NotInitialized = 2,
+  Unauthorized = 3,
+  WrapAlreadyExists = 4,
+  InvalidSignature = 5,
+  InvalidPeriod = 6,
+  MigrationAlreadyApplied = 7,
+  InvalidStateTransition = 8,
+  WrapNotFound = 9,
+  NoAdminTransferProposal = 10,
+  AdminTransferProposalExists = 11,
+  Paused = 12,
+  ArithmeticOverflow = 13,
+  InvalidFeeParams = 14,
+  Slashed = 15,
+}
+
+// ─── DataKey variant discriminator ──────────────────────────────────────
+
+export enum DataKeyVariant {
+  Admin = 'Admin',
+  AdminPubKey = 'AdminPubKey',
+  PendingAdmin = 'PendingAdmin',
+  Wrap = 'Wrap',
+  WrapCount = 'WrapCount',
+  LatestPeriod = 'LatestPeriod',
+  MigrationVersion = 'MigrationVersion',
+  UserPeriods = 'UserPeriods',
+  TotalWrapCount = 'TotalWrapCount',
+  TotalRevoked = 'TotalRevoked',
+  AliasHash = 'AliasHash',
+  Name = 'Name',
+  Symbol = 'Symbol',
+  Paused = 'Paused',
+  StorageBytes = 'StorageBytes',
+  FeeParams = 'FeeParams',
+  SlashCount = 'SlashCount',
+  Slashed = 'Slashed',
+  SlashThreshold = 'SlashThreshold',
+}
+
+// ─── Decoded storage key ────────────────────────────────────────────────
+
+export type DecodedKey =
+  | { variant: DataKeyVariant.Admin }
+  | { variant: DataKeyVariant.AdminPubKey }
+  | { variant: DataKeyVariant.PendingAdmin }
+  | { variant: DataKeyVariant.Wrap; user: string; period: number }
+  | { variant: DataKeyVariant.WrapCount; user: string }
+  | { variant: DataKeyVariant.LatestPeriod; user: string }
+  | { variant: DataKeyVariant.MigrationVersion }
+  | { variant: DataKeyVariant.UserPeriods; user: string }
+  | { variant: DataKeyVariant.TotalWrapCount }
+  | { variant: DataKeyVariant.TotalRevoked }
+  | { variant: DataKeyVariant.AliasHash; user: string }
+  | { variant: DataKeyVariant.Name }
+  | { variant: DataKeyVariant.Symbol }
+  | { variant: DataKeyVariant.Paused }
+  | { variant: DataKeyVariant.StorageBytes }
+  | { variant: DataKeyVariant.FeeParams }
+  | { variant: DataKeyVariant.SlashCount; user: string }
+  | { variant: DataKeyVariant.Slashed; user: string }
+  | { variant: DataKeyVariant.SlashThreshold };
+
+// ─── Value types ────────────────────────────────────────────────────────
+
+export interface WrapLifecycleFSM {
+  state: WrapState;
+  updated_at: number;
+}
+
+export interface WrapRecord {
+  timestamp: number;
+  data_hash: string; // hex-encoded 32 bytes
+  archetype: string;
+  period: number;
+  fsm: WrapLifecycleFSM;
+}
+
+export interface FeeParams {
+  base_fee: bigint;
+  per_kib_fee: bigint;
+  scale_step_kib: number;
+  max_fee: bigint;
+}
+
+export interface ContractHealth {
+  initialized: boolean;
+  has_admin: boolean;
+  has_signing_key: boolean;
+}
+
+// ─── Storage entry (decoded) ────────────────────────────────────────────
+
+export type DecodedStorageValue =
+  | { type: 'address'; value: string }
+  | { type: 'bytes32'; value: string }
+  | { type: 'u64'; value: number }
+  | { type: 'u32'; value: number }
+  | { type: 'bool'; value: boolean }
+  | { type: 'string'; value: string }
+  | { type: 'wrap_record'; value: WrapRecord }
+  | { type: 'wrap_state'; value: WrapState }
+  | { type: 'fee_params'; value: FeeParams }
+  | { type: 'bytes'; value: string }
+  | { type: 'u64_vec'; value: number[] }
+  | { type: 'i128'; value: bigint };
+
+export interface StorageEntry {
+  key: DecodedKey;
+  value: DecodedStorageValue;
+  ledger: number;
+  durability: 'persistent' | 'temporary' | 'instance';
+}
+
+// ─── Event types ────────────────────────────────────────────────────────
+
+export type EventTopic =
+  | { type: 'symbol'; value: string }
+  | { type: 'address'; value: string }
+  | { type: 'u64'; value: number }
+  | { type: 'u32'; value: number }
+  | { type: 'bool'; value: boolean }
+  | { type: 'bytes'; value: string };
+
+export interface ContractEvent {
+  id: string;
+  contract_id: string;
+  ledger: number;
+  ledger_close_at: string | null;
+  tx_hash: string;
+  topics: EventTopic[];
+  data: DecodedStorageValue;
+  failed_call: boolean;
+}
+
+export type EventType =
+  | 'mint'
+  | 'revoke'
+  | 'transition'
+  | 'init'
+  | 'pause'
+  | 'upgrade'
+  | 'admin_update'
+  | 'slash_report'
+  | 'slash_clear'
+  | 'slash_threshold'
+  | 'unknown';
+
+export interface TypedEvent {
+  raw: ContractEvent;
+  event_type: EventType;
+  parsed: Record<string, unknown>;
+}
+
+// ─── Database row types ─────────────────────────────────────────────────
+
+export interface WrapRow {
+  contract_id: string;
+  user: string;
+  period: number;
+  timestamp: number;
+  data_hash: string;
+  archetype: string;
+  fsm_state: number;
+  fsm_updated_at: number;
+  ledger_seq: number;
+  tx_hash: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface EventRow {
+  id: string;
+  contract_id: string;
+  event_type: string;
+  ledger_seq: number;
+  tx_hash: string;
+  topics_json: string;
+  data_json: string;
+  failed_call: boolean;
+  created_at: string;
+}
+
+export interface UserStateRow {
+  contract_id: string;
+  user: string;
+  wrap_count: number;
+  latest_period: number | null;
+  alias_hash: string | null;
+  slash_count: number;
+  is_slashed: boolean;
+  periods_json: string;
+  ledger_seq: number;
+  updated_at: string;
+}
+
+export interface ContractStateRow {
+  contract_id: string;
+  admin: string | null;
+  admin_pubkey: string | null;
+  pending_admin: string | null;
+  migration_version: number;
+  is_paused: boolean;
+  total_wrap_count: number;
+  total_revoked: number;
+  storage_bytes: number;
+  slash_threshold: number;
+  ledger_seq: number;
+  updated_at: string;
+}
+
+export interface LedgerCursorRow {
+  id: string;
+  contract_id: string;
+  last_processed_ledger: number;
+  last_event_ledger: number;
+  updated_at: string;
+}
+
+// ─── Derived State (in-memory index) ─────────────────────────────────────
+
+export interface DerivedState {
+  contract_id: string;
+  ledger_seq: number;
+  wraps: Map<string, Map<number, WrapRecord>>;
+  userCounts: Map<string, number>;
+  userLatestPeriods: Map<string, number>;
+  userPeriods: Map<string, number[]>;
+  userAliasHashes: Map<string, string>;
+  userSlashCounts: Map<string, number>;
+  userSlashed: Map<string, boolean>;
+  admin: string | null;
+  adminPubKey: string | null;
+  pendingAdmin: string | null;
+  migrationVersion: number;
+  paused: boolean;
+  totalWrapCount: number;
+  totalRevoked: number;
+  storageBytes: number;
+  slashThreshold: number;
+  name: string | null;
+  symbol: string | null;
+}
+
+// ─── Configuration ──────────────────────────────────────────────────────
+
+export interface IndexerConfig {
+  rpc_url: string;
+  contract_id: string;
+  db_path: string;
+  poll_interval_ms: number;
+  event_page_size: number;
+  start_ledger: number;
+  backfill: boolean;
+  reconcile_only: boolean;
+}

--- a/pipeline/tsconfig.json
+++ b/pipeline/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pipeline/vitest.config.ts
+++ b/pipeline/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    exclude: ['node_modules', 'dist'],
+    testTimeout: 10000,
+  },
+});


### PR DESCRIPTION
I replaced `better-sqlite3` (native compilation required) with `sql.js` (pure WASM) and fixed all resulting TypeScript type errors across the pipeline source and test files, achieving 57 passing tests with zero tsc errors.

closes #528
closes #529