### PR TITLE
test(ci): add release build smoke test for wasm32 target - in prog

### DIFF
--- a/docs/signing-payload.md
+++ b/docs/signing-payload.md
@@ -156,6 +156,7 @@ fn sign_payload(
 
 ---
 
+
 ## Error reference
 
 | Code | Name | Triggered when |


### PR DESCRIPTION

## Summary

This PR adds a release build smoke test to verify that the Stellar smart contract successfully compiles for the `wasm32-unknown-unknown` target in release mode.

### Changes Included

- Added a documented release build command:
  ```bash
  cargo build --release --target wasm32-unknown-unknown

in prog



Closes #261 



