### PR TITLE
security: Add invalid admin pubkey validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ You need:
 - `ADMIN_ADDRESS`: Your admin Stellar address (public)
 - `ADMIN_PUBKEY`: The 32-byte public key of your Ed25519 signing key
 
+> `ADMIN_PUBKEY` must be a valid Ed25519 public key. The contract rejects
+> obviously invalid keys — the all-zero key and the Ed25519 identity point —
+> with `Error(Contract, #48)` (`InvalidAdminPubkey`).
+
 To get your Ed25519 public key from your private signing key:
 
 ```bash
@@ -589,6 +593,7 @@ Mint a new wrap to confirm the upgraded code handles write operations correctly:
 | Symptom | Likely cause | Resolution |
 |---------|-------------|------------|
 | `Error(Contract, #2)` — `NotInitialized` | Contract has not been `initialize()`'d | Call `initialize(admin, admin_pubkey)` first |
+| `Error(Contract, #48)` — `InvalidAdminPubkey` | `admin_pubkey` is the all-zero key or the Ed25519 identity point | Pass a real 32-byte Ed25519 public key to `initialize()` |
 | `Error(Contract, #3)` — `Unauthorized` | `--source` is not the admin address | Use the correct admin secret key |
 | `HostError: ...wasm hash...` | WASM hash does not match any uploaded blob | Re-upload the WASM and verify the hash |
 | `Error(Contract, #7)` — `MigrationAlreadyApplied` | `migrate` called twice with same version | Check `migration_version()` first; this is not a real error |

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -11,9 +11,22 @@ pub(crate) fn read_admin(e: &Env) -> Address {
         .unwrap_or_else(|| panic_with_error!(e, ContractError::NotInitialized))
 }
 
+/// Rejects obviously invalid Ed25519 signing public keys that would otherwise
+/// make every signature check trivially forgeable or unusable:
+/// the all-zero key and the identity (neutral) point.
+fn is_invalid_admin_pubkey(pubkey: &BytesN<32>) -> bool {
+    let bytes = pubkey.to_array();
+    let is_all_zero = bytes.iter().all(|b| *b == 0);
+    let is_identity = bytes[0] == 1 && bytes[1..].iter().all(|b| *b == 0);
+    is_all_zero || is_identity
+}
+
 pub(crate) fn initialize(e: Env, admin: Address, admin_pubkey: BytesN<32>) {
     if e.storage().instance().has(&DataKey::Admin) {
         panic_with_error!(e, ContractError::AlreadyInitialized);
+    }
+    if is_invalid_admin_pubkey(&admin_pubkey) {
+        panic_with_error!(e, ContractError::InvalidAdminPubkey);
     }
     e.storage().instance().set(&DataKey::Admin, &admin);
     e.storage()

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -56,5 +56,6 @@ pub enum ContractError {
     // Expiration errors
     WrapNotExpired = 46,
     InvalidExpirationDuration = 47,
+    InvalidAdminPubkey = 48,
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -222,6 +222,46 @@ fn test_initialize_twice_fails() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #48)")]
+fn test_initialize_rejects_zero_admin_pubkey() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let zero_pubkey = BytesN::from_array(&env, &[0u8; 32]);
+
+    client.initialize(&admin, &zero_pubkey);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #48)")]
+fn test_initialize_rejects_identity_admin_pubkey() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let mut identity = [0u8; 32];
+    identity[0] = 1;
+    let identity_pubkey = BytesN::from_array(&env, &identity);
+
+    client.initialize(&admin, &identity_pubkey);
+}
+
+#[test]
+fn test_initialize_accepts_valid_admin_pubkey() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let signing_key = SigningKey::from_bytes(&[1u8; 32]);
+    let admin_pubkey = BytesN::from_array(&env, &signing_key.verifying_key().to_bytes());
+
+    client.initialize(&admin, &admin_pubkey);
+
+    assert!(client.health().initialized);
+}
+
+#[test]
 fn test_health_reflects_initialization_state() {
     let env = Env::default();
     let contract_id = env.register_contract(None, StellarWrapContract);


### PR DESCRIPTION
## Summary

Closes #266. Adds validation of the `admin_pubkey` passed to `initialize()`,
rejecting obviously invalid Ed25519 signing public keys that would otherwise
make every signature check trivially forgeable or unusable.

## Context

Initialization should reject obviously invalid signing public keys such as
all-zero bytes.

## Validation rules

`initialize(admin, admin_pubkey)` now panics with `Error(Contract, #48)`
(`InvalidAdminPubkey`) when `admin_pubkey` is:

- the all-zero key (`0x00...00`), or
- the Ed25519 identity (neutral) point (`0x01 0x00...00`).

Any real 32-byte Ed25519 public key continues to be accepted.

## Changes

- `src/errors.rs`: add `ContractError::InvalidAdminPubkey = 48`
- `src/admin.rs`: reject invalid keys inside `initialize()`
- `src/test.rs`: add tests for rejected (zero, identity) and accepted keys
- `README.md`: document the new validation in the initialization guide and
  failure-modes table

## Acceptance Criteria

- [x] Decide validation rules for `admin_pubkey`
- [x] Add tests for rejected and accepted keys
- [x] Update README initialization docs

## References

- `src/lib.rs`
- `README.md`

## Testing

- `cargo test` — new tests `test_initialize_rejects_zero_admin_pubkey`,
  `test_initialize_rejects_identity_admin_pubkey`,
  `test_initialize_accepts_valid_admin_pubkey` all pass