### PR TITLE
Add explicit .rustfmt.toml configuration

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,16 @@
+edition = "2021"
+max_width = 100
+use_small_heuristics = "Default"
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+reorder_imports = true
+reorder_modules = true
+use_field_init_shorthand = true
+use_try_shorthand = true
+format_strings = false
+tab_spaces = 4
+hard_tabs = false
+newline_style = "Unix"
+trailing_comma = "Vertical"
+trailing_semicolon = true
+match_block_trailing_comma = true


### PR DESCRIPTION
 Add explicit .rustfmt.toml configuration
  
  Adds a .rustfmt.toml file to the project root to make formatting rules explicit and consistent
  across all contributors, CI, and editor integrations. Previously, cargo fmt ran with rustfmt
  defaults, which could produce inconsistent results depending on the developer's local rustfmt
  version or settings.
  
  Changes:
  
  - Added .rustfmt.toml with the following configuration:
    - edition = "2021" — aligned with Cargo.toml
    - max_width = 100 — slightly wider than the 80-char default, common in Rust projects
    - imports_granularity = "Crate" and group_imports = "StdExternalCrate" — consistent import
  grouping (std → external → internal)
    - reorder_imports and reorder_modules — enforces alphabetical ordering
    - use_field_init_shorthand and use_try_shorthand — idiomatic Rust style
    - format_strings = false — avoids wrapping long string literals (relevant for hex/test data
  in Soroban contracts)
    - trailing_comma = "Vertical" and match_block_trailing_comma = true — consistent trailing
  comma style
    - Unix line endings (newline_style = "Unix")
  
  Testing:
  
  - No logic changes; formatting-only configuration.
  - cargo fmt --check should be run in CI to enforce this config going forward.

closes #506 