### PR TITLE
test: Cover verify_data before initialization

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -383,6 +383,4 @@ mod tests {
         )
         .is_ok());
     }
-
->>>>>>> main
 }

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -169,7 +169,6 @@ pub struct TransferFeeConfig {
     /// Soroban token contract used to collect fees.
     pub token: Address,
 }
-}
 
 #[contracttype]
 #[derive(Clone)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -7,7 +7,7 @@ use crate::test_utils::sign_payload;
 use ed25519_dalek::SigningKey;
 use soroban_sdk::{
     symbol_short,
-    testutils::{Address as _, Events},
+    testutils::{storage::Persistent as _, storage::Temporary as _, Address as _, Events},
     Address, Bytes, BytesN, Env, String, Symbol, TryIntoVal,
 };
 use std::vec::Vec;
@@ -1916,6 +1916,35 @@ fn test_balance_of_before_initialize() {
     // Contract is NOT initialized — no admin, no signing key.
     // balance_of must still return 0 without panicking.
     assert_eq!(client.balance_of(&user), 0);
+}
+
+#[test]
+fn test_verify_data_before_initialize() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let user = Address::generate(&env);
+    let period = 202401u64;
+    let data = Bytes::from_slice(&env, b"arbitrary data payload");
+
+    // Snapshot storage before the call.
+    let persistent_before = env.as_contract(&contract_id, || env.storage().persistent().all());
+    let temporary_before = env.as_contract(&contract_id, || env.storage().temporary().all());
+
+    // Contract is NOT initialized — no wrap records exist, so verify_data
+    // must deterministically return false without panicking.
+    assert!(!client.verify_data(&user, &period, &data));
+
+    // verify_data is a read-only query: it must not write any storage entries.
+    assert_eq!(
+        env.as_contract(&contract_id, || env.storage().persistent().all()),
+        persistent_before
+    );
+    assert_eq!(
+        env.as_contract(&contract_id, || env.storage().temporary().all()),
+        temporary_before
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Context

`verify_data` should have deterministic behavior before the contract is initialized.

## Acceptance Criteria

- Add a test that calls `verify_data` before initialization.
- Assert it returns false.
- Ensure no storage writes occur.

## References

- `src/lib.rs`
- `src/test.rs`

## Notes

- Adds `test_verify_data_before_initialize` in `src/test.rs`, which snapshots persistent/temporary storage before the call and asserts it remains unchanged afterwards, so `verify_data` performs no storage writes before initialization.
- Also removes two merge artifacts left on `main` that prevented the crate from compiling: a stray `>>>>>>> main` conflict marker in `src/signature.rs` and a duplicate closing brace in `src/storage_types.rs`.

Fixes #245
