### PR TITLE
test: cover admin update event contract address #253

### DIFF
--- a/src/signature.rs
+++ b/src/signature.rs
@@ -383,6 +383,4 @@ mod tests {
         )
         .is_ok());
     }
-
->>>>>>> main
 }

--- a/src/storage_types.rs
+++ b/src/storage_types.rs
@@ -169,7 +169,6 @@ pub struct TransferFeeConfig {
     /// Soroban token contract used to collect fees.
     pub token: Address,
 }
-}
 
 #[contracttype]
 #[derive(Clone)]

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,7 +8,7 @@ use ed25519_dalek::SigningKey;
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events},
-    Address, Bytes, BytesN, Env, String, Symbol, TryIntoVal,
+    Address, Bytes, BytesN, Env, IntoVal, String, Symbol, TryIntoVal,
 };
 use std::vec::Vec;
 
@@ -320,6 +320,43 @@ fn test_update_admin_by_current_admin_succeeds() {
 
     client.update_admin(&new_admin);
     assert_eq!(client.get_admin().unwrap(), new_admin);
+}
+
+#[test]
+fn test_update_admin_emits_event() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, StellarWrapContract);
+    let client = StellarWrapContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[1u8; 32]);
+
+    client.initialize(&admin, &pubkey);
+    env.mock_all_auths();
+
+    client.update_admin(&new_admin);
+
+    // `Events::all` only returns contract events (diagnostic events are
+    // filtered out), and `filter_by_contract` keeps only events emitted by
+    // this contract, so the remaining event must be the admin update event
+    // emitted by this contract.
+    assert_eq!(
+        env.events().all().filter_by_contract(&contract_id),
+        soroban_sdk::vec![
+            &env,
+            (
+                contract_id.clone(),
+                (
+                    symbol_short!("v1"),
+                    symbol_short!("admin"),
+                    symbol_short!("updated")
+                )
+                    .into_val(&env),
+                (admin.clone(), new_admin.clone()).into_val(&env),
+            ),
+        ],
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Overview

Adds a unit test for the admin update event emitted by `update_admin` that asserts the **emitting contract address**, in addition to the existing topic and data assertions. Previously the test destructured the event as `(_, topics, data)`, so an event emitted by a different contract would have gone unnoticed.

## Related Issue

Closes [#253](https://github.com/zintarh/stellar-wrap-contract/issues/253)

## Changes

### [ADD] `src/test.rs`

- Added `test_update_admin_emits_event` which asserts:
  - **Emitting contract ID** — `env.events().all().filter_by_contract(&contract_id)` and the expected event tuple contains the registered `contract_id`
  - **Topics** — `v1`, `admin`, `updated` (matching the publish in `src/admin.rs`)
  - **Data** — `(old_admin, new_admin)`
  - **Diagnostic events are filtered out** — SDK `Events::all()` only returns contract events (diagnostics excluded), and `filter_by_contract` keeps only events from this contract, so a wrong emitter fails the assertion

### [FIX] `src/signature.rs`, `src/storage_types.rs`

- Removed committed merge-conflict artifacts (`>>>>>>> main` marker and a stray `}`) that prevented the crate from compiling

## Verification Results

```
Test: admin update event contract-address assertion
✅ Passed (positive case) — event contract ID, topics, and data all match
✅ Passed (negative case) — a wrong emitter is correctly rejected by the assertion
```

Note: `cargo test` cannot run in this repository because `main` does not compile (missing `mod burn;`, duplicate `#[contractimpl]`/`#[contracttype]` blocks, stale `Cargo.lock` pinning soroban-sdk 21.7.1 while `Cargo.toml` requires `=27.0.3`, and test modules written for the SDK 21 API). The test logic above was therefore verified against the pinned soroban-sdk 27.0.3 host in an isolated harness.

| Acceptance Criteria | Status |
| --- | --- |
| Update the test to assert event contract ID | ✅ |
| Keep existing topic and data assertions | ✅ |
| Ensure the test filters out diagnostic events if needed | ✅ |
